### PR TITLE
Option to create ClusterIP service for yugaware UI

### DIFF
--- a/modules/kubernetes/kubernetes-config/main.tf
+++ b/modules/kubernetes/kubernetes-config/main.tf
@@ -36,6 +36,10 @@ resource "helm_release" "yb-release" {
   version = var.chart_version
   namespace = kubernetes_namespace.yb_anywhere.metadata[0].name
   wait = true
+  set {
+    name = "yugaware.service.type"
+    value = var.service_type
+  }
 }
 
 data "kubernetes_service" "yb_anywhere" {

--- a/modules/kubernetes/kubernetes-config/outputs.tf
+++ b/modules/kubernetes/kubernetes-config/outputs.tf
@@ -1,3 +1,3 @@
 output "public_ip" {
-  value = data.kubernetes_service.yb_anywhere.status[0].load_balancer[0].ingress[0].ip
+  value = var.service_type == "ClusterIP" ? data.kubernetes_service.yb_anywhere.spec.0.cluster_ip : data.kubernetes_service.yb_anywhere.status.0.load_balancer.0.ingress.0.hostname
 }

--- a/modules/kubernetes/kubernetes-config/variables.tf
+++ b/modules/kubernetes/kubernetes-config/variables.tf
@@ -3,6 +3,12 @@ variable "cluster_name" {
   type = string
   default = "yb-anywhere"
 }
+
+variable "service_type" {
+  description = "Whether the Yugaware Service type should be LoadBalancer or ClusterIP"
+  type = string
+  default = "ClusterIP"
+}
 variable "docker_config_json" {
   description = ".dockerconfigjson field from provided Yugabyte kubernetes secret"
   type = string


### PR DESCRIPTION
We have a terraform module named `kubernetes-config` that installs YBA on a k8s cloud. It creates a public IP LoadBalancer always for the installed instance of YBA. This change exposes a `service_type` variable for this module so that users can choose to pass in a `service_type=ClusterIP` or `service_type=LoadBalancer` as per the needs. The module now outputs the IP address of YBA instance accordingly.

Tested by creating a terraform configuration that uses this module and verified that the output IP address corresponds to the ClusterIP of the yugaware UI service.
```
terraform {
  required_providers {
    aws = {
      source  = "hashicorp/aws"
    }
    kubernetes = {
      source  = "hashicorp/kubernetes"
      version = ">= 2.0.3"
    }
    helm = {
      source  = "hashicorp/helm"
      version = ">= 2.1.0"
    }
  }
}

locals {
  eks_cluster_name = "sneelakantan-eks"
  eks_region = "ap-south-1"
  yba = "yba"
  pull_secret_file = "~/.yugabyte/yugabyte-k8s-secret.yml"
}

provider "aws" {
  region = local.eks_region
}

# Fetch details of the EKS cluster from AWS
data "aws_eks_cluster" "yb-anywhere" {
  name = local.eks_cluster_name
}

# Fetch the authentication details from EKS cluster to use for kubeconfig
data "aws_eks_cluster_auth" "yb-anywhere" {
  name = local.eks_cluster_name
}

# Point kubernertes provider to EKS cluster endpoint and auth.
# This provider is required by the kubernetes-config module used below.
provider "kubernetes" {
  host = data.aws_eks_cluster.yb-anywhere.endpoint
  cluster_ca_certificate = base64decode(data.aws_eks_cluster.yb-anywhere.certificate_authority[0].data)
  token = data.aws_eks_cluster_auth.yb-anywhere.token
}

# Point helm provider to EKS cluster endpoint and auth.
# This provider is required by the kubernetes-config module used below.
provider "helm" {
  kubernetes {
    host                   = data.aws_eks_cluster.yb-anywhere.endpoint
    cluster_ca_certificate = base64decode(data.aws_eks_cluster.yb-anywhere.certificate_authority[0].data)
    token                  = data.aws_eks_cluster_auth.yb-anywhere.token
  }
}

# Finally, use the kubernetes-config module to install a YBA instance in the EKS cluster
module "kubernetes-config" {
  source             = "../../../../modules/kubernetes/kubernetes-config"
  docker_config_json = base64decode(yamldecode(file(local.pull_secret_file))["data"][".dockerconfigjson"])
  cluster_name       = local.yba
  chart_version = "2.15.3"
}

output "public_ip" {
  value = module.kubernetes-config.public_ip
}
```