### PR TITLE
Updating to latest platform-go-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/yugabyte/platform-go-client v0.0.0-20220316000403-72690ff08ac1
+	github.com/yugabyte/platform-go-client v0.0.0-20230104063056-6f4f860176cb
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,6 +420,8 @@ github.com/yugabyte/platform-go-client v0.0.0-20220308232516-f7d106d1bdaa h1:P8P
 github.com/yugabyte/platform-go-client v0.0.0-20220308232516-f7d106d1bdaa/go.mod h1:DCweVAOmhBcxKl4aAmsBDVI6K1VZXHkLRcCCLgZnwj0=
 github.com/yugabyte/platform-go-client v0.0.0-20220316000403-72690ff08ac1 h1:IHJD5PTbYnDZSGkwo185RTSSEr8Qg3vCk6FCkRUaiaQ=
 github.com/yugabyte/platform-go-client v0.0.0-20220316000403-72690ff08ac1/go.mod h1:DCweVAOmhBcxKl4aAmsBDVI6K1VZXHkLRcCCLgZnwj0=
+github.com/yugabyte/platform-go-client v0.0.0-20230104063056-6f4f860176cb h1:IwvMKeHFjDHiPLuocoD1VfLjJKw2BLjAMg+9kKBFbI4=
+github.com/yugabyte/platform-go-client v0.0.0-20230104063056-6f4f860176cb/go.mod h1:DCweVAOmhBcxKl4aAmsBDVI6K1VZXHkLRcCCLgZnwj0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
Adjusted the provider code as per the latest go client. Minor changes were needed in the way Cloud Provider details are specified via the updated API.

Manually tested that the examples/docker/gcp_prov_gcp goes through correctly.