### PR TITLE
Revert "Updating to latest platform-go-client"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/posener/complete v1.2.3 // indirect
 	github.com/rogpeppe/go-internal v1.8.1 // indirect
-	github.com/yugabyte/platform-go-client v0.0.0-20230104063056-6f4f860176cb
+	github.com/yugabyte/platform-go-client v0.0.0-20220316000403-72690ff08ac1
 	golang.org/x/crypto v0.0.0-20220315160706-3147a52a75dd // indirect
 	golang.org/x/net v0.0.0-20220121210141-e204ce36a2ba // indirect
 	golang.org/x/sys v0.0.0-20220114195835-da31bd327af9 // indirect

--- a/go.sum
+++ b/go.sum
@@ -420,8 +420,6 @@ github.com/yugabyte/platform-go-client v0.0.0-20220308232516-f7d106d1bdaa h1:P8P
 github.com/yugabyte/platform-go-client v0.0.0-20220308232516-f7d106d1bdaa/go.mod h1:DCweVAOmhBcxKl4aAmsBDVI6K1VZXHkLRcCCLgZnwj0=
 github.com/yugabyte/platform-go-client v0.0.0-20220316000403-72690ff08ac1 h1:IHJD5PTbYnDZSGkwo185RTSSEr8Qg3vCk6FCkRUaiaQ=
 github.com/yugabyte/platform-go-client v0.0.0-20220316000403-72690ff08ac1/go.mod h1:DCweVAOmhBcxKl4aAmsBDVI6K1VZXHkLRcCCLgZnwj0=
-github.com/yugabyte/platform-go-client v0.0.0-20230104063056-6f4f860176cb h1:IwvMKeHFjDHiPLuocoD1VfLjJKw2BLjAMg+9kKBFbI4=
-github.com/yugabyte/platform-go-client v0.0.0-20230104063056-6f4f860176cb/go.mod h1:DCweVAOmhBcxKl4aAmsBDVI6K1VZXHkLRcCCLgZnwj0=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/cloud_provider/resource_cloud_provider.go
+++ b/internal/cloud_provider/resource_cloud_provider.go
@@ -4,15 +4,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
-	"time"
-
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	client "github.com/yugabyte/platform-go-client"
 	"github.com/yugabyte/terraform-provider-yugabyte-platform/internal/api"
 	"github.com/yugabyte/terraform-provider-yugabyte-platform/internal/utils"
+	"net/http"
+	"time"
 )
 
 func ResourceCloudProvider() *schema.Resource {
@@ -139,8 +138,10 @@ func resourceCloudProviderCreate(ctx context.Context, d *schema.ResourceData, me
 	cUUID := meta.(*api.ApiClient).CustomerId
 
 	req := client.Provider{
+		AirGapInstall:        utils.GetBoolPointer(d.Get("air_gap_install").(bool)),
 		Code:                 utils.GetStringPointer(d.Get("code").(string)),
 		Config:               utils.StringMap(d.Get("config").(map[string]interface{})),
+		CustomHostCidrs:      utils.StringSlice(d.Get("custom_host_cidrs").([]interface{})),
 		DestVpcId:            utils.GetStringPointer(d.Get("dest_vpc_id").(string)),
 		HostVpcId:            utils.GetStringPointer(d.Get("host_vpc_id").(string)),
 		HostVpcRegion:        utils.GetStringPointer(d.Get("host_vpc_region").(string)),
@@ -148,13 +149,10 @@ func resourceCloudProviderCreate(ctx context.Context, d *schema.ResourceData, me
 		HostedZoneName:       utils.GetStringPointer(d.Get("hosted_zone_name").(string)),
 		KeyPairName:          utils.GetStringPointer(d.Get("key_pair_name").(string)),
 		Name:                 utils.GetStringPointer(d.Get("name").(string)),
+		SshPort:              utils.GetInt32Pointer(int32(d.Get("ssh_port").(int))),
 		SshPrivateKeyContent: utils.GetStringPointer(d.Get("ssh_private_key_content").(string)),
-		Details: client.ProviderDetails{
-			AirGapInstall: utils.GetBoolPointer(d.Get("air_gap_install").(bool)),
-			SshPort:       utils.GetInt32Pointer(int32(d.Get("ssh_port").(int))),
-			SshUser:       utils.GetStringPointer(d.Get("ssh_user").(string)),
-		},
-		Regions: buildRegions(d.Get("regions").([]interface{})),
+		SshUser:              utils.GetStringPointer(d.Get("ssh_user").(string)),
+		Regions:              buildRegions(d.Get("regions").([]interface{})),
 	}
 	r, _, err := c.CloudProvidersApi.CreateProviders(ctx, cUUID).CreateProviderRequest(req).Execute()
 	if err != nil {
@@ -198,13 +196,16 @@ func resourceCloudProviderRead(ctx context.Context, d *schema.ResourceData, meta
 		return diag.FromErr(err)
 	}
 
-	if err = d.Set("air_gap_install", p.Details.AirGapInstall); err != nil {
+	if err = d.Set("air_gap_install", p.AirGapInstall); err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("code", p.Code); err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("computed_config", p.Config); err != nil {
+		return diag.FromErr(err)
+	}
+	if err = d.Set("custom_host_cidrs", p.CustomHostCidrs); err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("hosted_zone_id", p.HostedZoneId); err != nil {
@@ -216,13 +217,13 @@ func resourceCloudProviderRead(ctx context.Context, d *schema.ResourceData, meta
 	if err = d.Set("name", p.Name); err != nil {
 		return diag.FromErr(err)
 	}
-	if err = d.Set("ssh_port", p.Details.SshPort); err != nil {
+	if err = d.Set("ssh_port", p.SshPort); err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("ssh_private_key_content", p.SshPrivateKeyContent); err != nil {
 		return diag.FromErr(err)
 	}
-	if err = d.Set("ssh_user", p.Details.SshUser); err != nil {
+	if err = d.Set("ssh_user", p.SshUser); err != nil {
 		return diag.FromErr(err)
 	}
 	if err = d.Set("regions", flattenRegions(p.Regions)); err != nil {


### PR DESCRIPTION
This reverts commit e0a3491d2387c7df160bc575dd46bf9a125e653a.

Reverting since the latest generated go-client breaks terraform workflows. There are Date format deserialisation errors from latest go-client. Will regenerate the go-client after fixing all of them in YBA. Until then using the older platform-go-client.