### PR TITLE
Accommodate fetching api_token from authenticated provider for importi…

### DIFF
--- a/internal/customer/resource_customer.go
+++ b/internal/customer/resource_customer.go
@@ -123,17 +123,6 @@ func resourceCustomerRead(ctx context.Context, d *schema.ResourceData, meta inte
 	if err = d.Set("cuuid", *r.CustomerUUID); err != nil {
 		return diag.FromErr(err)
 	}
-
-	res, _, err := new_client.CustomerManagementApi.CustomerDetail(ctx, *r.CustomerUUID).Execute()
-
-	if err = d.Set("code", res.Code); err != nil {
-		return diag.FromErr(err)
-	}
-
-	if err = d.Set("name", res.Name); err != nil {
-		return diag.FromErr(err)
-	}
-
 	d.SetId(*r.CustomerUUID)
 	return diags
 }


### PR DESCRIPTION
…ng customers

In the event that a customer resource is imported, a 403 Error is thrown because the contents of the resource in the state file does not contain the required api token (d.Get("api_token") will be empty). In that case, we retrieve the information from the Vanilla Client, which is instantiated when a new yba provider is defined in the configuration file (Needs to have both host and api_token defined to import customers). 