### PR TITLE
Accommodate changes in replicated.yml

### DIFF
--- a/modules/resources/application_settings.conf
+++ b/modules/resources/application_settings.conf
@@ -5,13 +5,11 @@
   },
   "enable_proxy": {},
   "hostname": {},
-  "http_proxy": {},
+  "http_enabled": {
+    "value": "1"
+  },
   "https_enabled": {
     "value": "0"
-  },
-  "https_proxy": {},
-  "nginx_external_port": {
-    "value": "80"
   },
   "no_proxy": {},
   "prometheus_retention": {


### PR DESCRIPTION
The current application structure no longer has an NGINX container running to connect to the app. This has led to changes in the replicated.yml file, and needs corresponding changes in the application_settings.conf file.

HTTPS is kept as disabled as the current go-client makes API calls via HTTP protocol. Once a regenerated client can be used, https_enabled can be set to 1 and the ports in the main.tf for provider can be changed to 443

> Works with the old replicated format as well