### PR TITLE
Fix registry name in module

### DIFF
--- a/modules/installation/main.tf
+++ b/modules/installation/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     yba = {
-      version = "~> 0.1.0"
-      source  = "terraform.yugabyte.com/platform/yba"
+      version = "~> 0.1.6"
+      source  = "yugabyte/yba"
     }
   }
 }


### PR DESCRIPTION


### Description
Need this fix in order to use this module. Without this fix, `terraform init` fails to find the yugabyte YBA provider and fails.


### Relations
<!---
If your pull request fully resolves and should automatically close the linked issue, use Closes. Otherwise, use Relates.

For Example:

Relates #0000
or 
Closes #0000
--->

Closes #0000

### References
<!---
Optionally, provide any helpful references that may help the reviewer(s).
--->


### Output from Acceptance Testing


```
$ make testacc

...
```
