### PR TITLE
[PLAT-20664] Add missing arch field to ImageBundleSchema

### DIFF
--- a/internal/provider/providerutil/schemas.go
+++ b/internal/provider/providerutil/schemas.go
@@ -105,6 +105,11 @@ func ImageBundleSchema() *schema.Schema {
 					MaxItems: 1,
 					Elem: &schema.Resource{
 						Schema: map[string]*schema.Schema{
+							"arch": {
+								Type:        schema.TypeString,
+								Computed:    true,
+								Description: "Image bundle architecture. Read-only for GCP (always x86_64).",
+							},
 							"ssh_user": {
 								Type:        schema.TypeString,
 								Required:    true,


### PR DESCRIPTION
### Description

The flattenImageBundleDetails() function returns an arch field for all cloud providers, but ImageBundleSchema() did not define it in the details block. This caused yba_gcp_provider to fail during READ with:

```
Error: Invalid address to set: []string{"image_bundles", "0", "details", "0", "arch"}
```

Add arch as a Computed field since it's read-only and returned by the YBA API. This unblocks migration from the deprecated yba_cloud_provider to yba_gcp_provider.


### Relations

Closes PLAT-20664

### Output from Acceptance Testing

The actual code that works now:

```
resource "yba_gcp_provider" "gcp" {
  count = var.gcp_provider != null ? 1 : 0

  name                 = var.gcp_provider.name
  use_host_credentials = true
  project_id           = var.gcp_provider.project_id
  network              = var.gcp_provider.network

  regions {
    code          = var.gcp_provider.region
    shared_subnet = var.gcp_provider.shared_subnet
  }

  dynamic "image_bundles" {
    for_each = var.gcp_provider.machine_image != null ? [var.gcp_provider.machine_image] : []
    content {
      name           = image_bundles.value.name
      use_as_default = true
      details {
        global_yb_image = image_bundles.value.image
        ssh_user        = var.gcp_provider.ssh_user
        ssh_port        = var.gcp_provider.ssh_port
      }
    }
  }

  set_up_chrony   = true
  air_gap_install = false
}
```