### PR TITLE
[PLAT-20663] Support pre-release YBA versions

### DIFF
--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 
@@ -50,6 +51,17 @@ type installerFileSpec struct {
 	// remotePath is where the contents are written on the remote host.
 	remotePath string
 }
+
+const (
+	// GADownloadURL is the base URL for GA release versions (e.g. 2024.x, 2025.x).
+	GADownloadURL = "https://downloads.yugabyte.com/releases"
+	// PreReleaseDownloadURL is the base URL for pre-release/CI builds (e.g. 2.25.x).
+	PreReleaseDownloadURL = "https://releases.yugabyte.com"
+)
+
+// gaVersionRegex matches GA release version strings, which begin with a 4-digit
+// year followed by a dot (e.g. "2024.1.0.0", "2025.2.3.0-b50").
+var gaVersionRegex = regexp.MustCompile(`^20\d{2}\.`)
 
 var (
 	tlsCertificateSpec = installerFileSpec{
@@ -565,8 +577,8 @@ func resourceYBAInstallerUpdate(
 				"updating license")
 			return diag.FromErr(err)
 		}
-		folder, _, _ := getYBAInstallerPackageString(oldVersion, hostOS, hostArch)
-		commands = append(commands, getAddLicenseCommands(folder))
+		folder, _, _ := getYBAInstallerPackageNames(oldVersion, hostOS, hostArch)
+		commands = append(commands, getAddLicenseCommand(oldVersion, folder))
 	}
 
 	reconfigureRequested := d.Get("reconfigure").(bool)
@@ -584,7 +596,7 @@ func resourceYBAInstallerUpdate(
 				"reconfiguration")
 			return diag.FromErr(err)
 		}
-		commands = append(commands, getReconfigureCommands()...)
+		commands = append(commands, getReconfigureCommands(oldVersion)...)
 	}
 
 	if d.HasChange("yba_version") {
@@ -625,7 +637,8 @@ func resourceYBAInstallerDelete(
 	}
 	defer func() { _ = sshClient.Close() }()
 
-	for _, cmd := range getDeleteCommands() {
+	ybaVersion := d.Get("yba_version").(string)
+	for _, cmd := range getDeleteCommands(ybaVersion) {
 		m, err := runCommand(ctx, sshClient, cmd)
 		if err != nil {
 			tflog.Error(ctx, m)
@@ -636,85 +649,105 @@ func resourceYBAInstallerDelete(
 	return diags
 }
 
-func getYBAInstallerPackageString(version, os, arch string) (folder, bundle, v string) {
+// IsGAVersion returns true for GA release versions (e.g. 2024.x, 2025.x).
+// Pre-release / CI builds use the legacy 2.x scheme (e.g. 2.25.0.0).
+func IsGAVersion(version string) bool {
+	return gaVersionRegex.MatchString(version)
+}
+
+// getYBAInstallerPackageNames derives the package naming pieces for a version:
+// the extracted folder name, the tarball base name, and the build-stripped
+// version used in GA download paths.
+func getYBAInstallerPackageNames(version, os, arch string) (folder, bundle, v string) {
 	folder = fmt.Sprintf("yba_installer_full-%s", version)
+	// Pre-release bundles are named "centos" rather than "linux".
+	if !IsGAVersion(version) && os == "linux" {
+		os = "centos"
+	}
 	bundle = fmt.Sprintf("%s-%s-%s", folder, os, arch)
-	vParts := strings.Split(version, "-")
-	// Get the version without build number to access remote folder for releases
-	v = vParts[0]
+	// Strip the build number ("-bNNN") to get the remote folder for GA releases.
+	v = strings.Split(version, "-")[0]
 	return folder, bundle, v
 }
 
-func getYBAInstallerBundle(version, os, arch string) (string, []string) {
-	getBundle := make([]string, 0)
-	folder, bundle, v := getYBAInstallerPackageString(version, os, arch)
-	s := fmt.Sprintf("curl -O https://downloads.yugabyte.com/releases/%s/%s.tar.gz", v, bundle)
-	getBundle = append(getBundle, s)
-	s = fmt.Sprintf("tar -xf %s.tar.gz", bundle)
-	getBundle = append(getBundle, s)
-	return folder, getBundle
+// getYBAInstallerDownloadURL returns the tarball URL for the given version, OS and
+// arch. GA versions come from downloads.yugabyte.com under the build-stripped
+// version path. Pre-release builds come from releases.yugabyte.com under the full
+// version including the build number.
+func getYBAInstallerDownloadURL(version, os, arch string) string {
+	_, bundle, v := getYBAInstallerPackageNames(version, os, arch)
+	if IsGAVersion(version) {
+		return fmt.Sprintf("%s/%s/%s.tar.gz", GADownloadURL, v, bundle)
+	}
+	return fmt.Sprintf("%s/%s/%s.tar.gz", PreReleaseDownloadURL, version, bundle)
+}
+
+// getBundleDownloadCommands returns the extracted folder name and the commands
+// that download and unpack the YBA Installer tarball.
+func getBundleDownloadCommands(version, os, arch string) (string, []string) {
+	folder, bundle, _ := getYBAInstallerPackageNames(version, os, arch)
+	commands := []string{
+		fmt.Sprintf("curl -O %s", getYBAInstallerDownloadURL(version, os, arch)),
+		fmt.Sprintf("tar -xf %s.tar.gz", bundle),
+	}
+	return folder, commands
+}
+
+// ybaCtlSudo returns the shell prefix for invoking yba-ctl. Pre-release builds add
+// YBA_MODE=dev to bypass the strict version checks that reject non-GA versions.
+func ybaCtlSudo(version string) string {
+	if IsGAVersion(version) {
+		return "sudo"
+	}
+	return "sudo YBA_MODE=dev"
+}
+
+// getAddLicenseCommand returns the yba-ctl invocation that registers the license file.
+func getAddLicenseCommand(version, folder string) string {
+	return fmt.Sprintf("%s ./%s/yba-ctl license add -l /tmp/license.lic",
+		ybaCtlSudo(version), folder)
 }
 
 func getInstallCommands(
 	version, os, arch string,
 	config bool, skipPreflightCheckList *[]string) []string {
-	var s string
-	folder, installationCommands := getYBAInstallerBundle(version, os, arch)
-	s = getAddLicenseCommands(folder)
-	installationCommands = append(installationCommands, s)
+	folder, installationCommands := getBundleDownloadCommands(version, os, arch)
+	installationCommands = append(installationCommands, getAddLicenseCommand(version, folder))
 	if config {
-		k := "sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml"
-		installationCommands = append(installationCommands, k)
+		installationCommands = append(installationCommands,
+			"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml")
 	}
-	s = fmt.Sprintf("sudo ./%s/yba-ctl install -f", folder)
+	s := fmt.Sprintf("%s ./%s/yba-ctl install -f", ybaCtlSudo(version), folder)
 	if skipPreflightCheckList != nil && len(*skipPreflightCheckList) != 0 {
-		skipPreflight := getSkipPreflightChecksSubCommand(*skipPreflightCheckList)
-		s = fmt.Sprintf("%s -s %s", s, skipPreflight)
+		s = fmt.Sprintf("%s -s %s", s, strings.Join(*skipPreflightCheckList, ","))
 	}
 	installationCommands = append(installationCommands, s)
 	return installationCommands
 }
 
-func getReconfigureCommands() []string {
+func getReconfigureCommands(version string) []string {
 	var reconfigureCommands = []string{"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml"}
-	s := "sudo /opt/yba-ctl/yba-ctl reconfigure -f"
-	reconfigureCommands = append(reconfigureCommands, s)
+	reconfigureCommands = append(reconfigureCommands,
+		fmt.Sprintf("%s /opt/yba-ctl/yba-ctl reconfigure -f", ybaCtlSudo(version)))
 	return reconfigureCommands
 }
 
 func getUpgradeCommands(version, os, arch string, skipPreflightCheckList *[]string) []string {
-	var s string
-	folder, updateCommands := getYBAInstallerBundle(version, os, arch)
-	s = fmt.Sprintf("sudo ./%s/yba-ctl upgrade -f", folder)
+	folder, updateCommands := getBundleDownloadCommands(version, os, arch)
+	s := fmt.Sprintf("%s ./%s/yba-ctl upgrade -f", ybaCtlSudo(version), folder)
 	if skipPreflightCheckList != nil && len(*skipPreflightCheckList) != 0 {
-		skipPreflight := getSkipPreflightChecksSubCommand(*skipPreflightCheckList)
-		s = fmt.Sprintf("%s -s %s", s, skipPreflight)
+		s = fmt.Sprintf("%s -s %s", s, strings.Join(*skipPreflightCheckList, ","))
 	}
 	updateCommands = append(updateCommands, s)
 	return updateCommands
 }
 
-func getAddLicenseCommands(folder string) string {
-	return fmt.Sprintf("sudo ./%s/yba-ctl license add -l /tmp/license.lic", folder)
-}
-
-func getDeleteCommands() []string {
-	var deleteCommands = []string{"sudo /opt/yba-ctl/yba-ctl clean"}
-	s := "sudo rm -rf /opt/yugabyte"
-	deleteCommands = append(deleteCommands, s)
-	s = "sudo rm /tmp/server.crt /tmp/server.key /tmp/license.lic /tmp/settings.yml"
-	deleteCommands = append(deleteCommands, s)
-	return deleteCommands
-}
-
-func getSkipPreflightChecksSubCommand(commands []string) string {
-	var s string
-	for i, v := range commands {
-		if i == 0 {
-			s = v
-		} else {
-			s = fmt.Sprintf("%s,%s", s, v)
-		}
+func getDeleteCommands(version string) []string {
+	var deleteCommands = []string{
+		fmt.Sprintf("%s /opt/yba-ctl/yba-ctl clean", ybaCtlSudo(version)),
 	}
-	return s
+	deleteCommands = append(deleteCommands, "sudo rm -rf /opt/yugabyte")
+	deleteCommands = append(deleteCommands,
+		"sudo rm /tmp/server.crt /tmp/server.key /tmp/license.lic /tmp/settings.yml")
+	return deleteCommands
 }

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -18,6 +18,7 @@ package installation
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -277,5 +278,426 @@ func TestInstallerSpecSets(t *testing.T) {
 	install[0] = installerFileSpec{}
 	if installationYBAInstallerSpecs()[0] == (installerFileSpec{}) {
 		t.Fatalf("installationYBAInstallerSpecs returned a shared/mutable slice")
+	}
+}
+
+func TestIsGAVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		expected bool
+	}{
+		{
+			name:     "GA version 2024.1.0.0",
+			version:  "2024.1.0.0",
+			expected: true,
+		},
+		{
+			name:     "GA version with build number",
+			version:  "2024.1.0.0-b129",
+			expected: true,
+		},
+		{
+			name:     "GA version 2024.2.3.0",
+			version:  "2024.2.3.0",
+			expected: true,
+		},
+		{
+			name:     "GA version 2025.1.0.0",
+			version:  "2025.1.0.0-b50",
+			expected: true,
+		},
+		{
+			name:     "Pre-release version 2.25.0.0",
+			version:  "2.25.0.0",
+			expected: false,
+		},
+		{
+			name:     "Pre-release version with build number",
+			version:  "2.25.0.0-b300",
+			expected: false,
+		},
+		{
+			name:     "Pre-release version 2.31.0.0",
+			version:  "2.31.0.0-b23",
+			expected: false,
+		},
+		{
+			name:     "Pre-release version 2.20.0.0",
+			version:  "2.20.0.0-b1",
+			expected: false,
+		},
+		{
+			name:     "Empty string is not GA",
+			version:  "",
+			expected: false,
+		},
+		{
+			name:     "Year without trailing dot is not GA",
+			version:  "2024",
+			expected: false,
+		},
+		{
+			name:     "Pre-2000 year is not GA",
+			version:  "1999.1.0.0",
+			expected: false,
+		},
+		{
+			name:     "Year must be at the start",
+			version:  "v2024.1.0.0",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsGAVersion(tt.version)
+			if result != tt.expected {
+				t.Errorf("IsGAVersion(%q) = %v, expected %v", tt.version, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetYBAInstallerPackageNames(t *testing.T) {
+	tests := []struct {
+		name           string
+		version        string
+		os             string
+		arch           string
+		expectedFolder string
+		expectedBundle string
+		expectedV      string
+	}{
+		{
+			name:           "GA version 2024.x uses linux",
+			version:        "2024.1.0.0-b129",
+			os:             "linux",
+			arch:           "x86_64",
+			expectedFolder: "yba_installer_full-2024.1.0.0-b129",
+			expectedBundle: "yba_installer_full-2024.1.0.0-b129-linux-x86_64",
+			expectedV:      "2024.1.0.0",
+		},
+		{
+			name:           "GA version 2025.x uses linux",
+			version:        "2025.2.2.2-b11",
+			os:             "linux",
+			arch:           "x86_64",
+			expectedFolder: "yba_installer_full-2025.2.2.2-b11",
+			expectedBundle: "yba_installer_full-2025.2.2.2-b11-linux-x86_64",
+			expectedV:      "2025.2.2.2",
+		},
+		{
+			name:           "Pre-release version converts linux to centos",
+			version:        "2.25.0.0-b300",
+			os:             "linux",
+			arch:           "x86_64",
+			expectedFolder: "yba_installer_full-2.25.0.0-b300",
+			expectedBundle: "yba_installer_full-2.25.0.0-b300-centos-x86_64",
+			expectedV:      "2.25.0.0",
+		},
+		{
+			name:           "Pre-release version with explicit centos",
+			version:        "2.25.0.0-b300",
+			os:             "centos",
+			arch:           "x86_64",
+			expectedFolder: "yba_installer_full-2.25.0.0-b300",
+			expectedBundle: "yba_installer_full-2.25.0.0-b300-centos-x86_64",
+			expectedV:      "2.25.0.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			folder, bundle, v := getYBAInstallerPackageNames(tt.version, tt.os, tt.arch)
+			if folder != tt.expectedFolder {
+				t.Errorf("folder = %q, expected %q", folder, tt.expectedFolder)
+			}
+			if bundle != tt.expectedBundle {
+				t.Errorf("bundle = %q, expected %q", bundle, tt.expectedBundle)
+			}
+			if v != tt.expectedV {
+				t.Errorf("v = %q, expected %q", v, tt.expectedV)
+			}
+		})
+	}
+}
+
+func TestGetYBAInstallerDownloadURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		os       string
+		arch     string
+		expected string
+	}{
+		{
+			name:     "GA version 2024.x uses downloads.yugabyte.com with build-stripped path and linux",
+			version:  "2024.1.0.0-b129",
+			os:       "linux",
+			arch:     "x86_64",
+			expected: "https://downloads.yugabyte.com/releases/2024.1.0.0/yba_installer_full-2024.1.0.0-b129-linux-x86_64.tar.gz",
+		},
+		{
+			name:     "GA version 2025.x uses downloads.yugabyte.com with build-stripped path and linux",
+			version:  "2025.2.2.2-b11",
+			os:       "linux",
+			arch:     "x86_64",
+			expected: "https://downloads.yugabyte.com/releases/2025.2.2.2/yba_installer_full-2025.2.2.2-b11-linux-x86_64.tar.gz",
+		},
+		{
+			name:     "GA version without build number keeps full version in path",
+			version:  "2024.1.0.0",
+			os:       "linux",
+			arch:     "x86_64",
+			expected: "https://downloads.yugabyte.com/releases/2024.1.0.0/yba_installer_full-2024.1.0.0-linux-x86_64.tar.gz",
+		},
+		{
+			name:     "Pre-release version uses releases.yugabyte.com with full version path and centos",
+			version:  "2.25.0.0-b300",
+			os:       "linux",
+			arch:     "x86_64",
+			expected: "https://releases.yugabyte.com/2.25.0.0-b300/yba_installer_full-2.25.0.0-b300-centos-x86_64.tar.gz",
+		},
+		{
+			name:     "GA version propagates aarch64 architecture into the URL",
+			version:  "2025.2.2.2-b11",
+			os:       "linux",
+			arch:     "aarch64",
+			expected: "https://downloads.yugabyte.com/releases/2025.2.2.2/yba_installer_full-2025.2.2.2-b11-linux-aarch64.tar.gz",
+		},
+		{
+			name:     "Pre-release version propagates aarch64 architecture into the URL",
+			version:  "2.25.0.0-b300",
+			os:       "linux",
+			arch:     "aarch64",
+			expected: "https://releases.yugabyte.com/2.25.0.0-b300/yba_installer_full-2.25.0.0-b300-centos-aarch64.tar.gz",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := getYBAInstallerDownloadURL(tt.version, tt.os, tt.arch)
+			if got != tt.expected {
+				t.Errorf("getYBAInstallerDownloadURL(%q, %q, %q) = %q, expected %q",
+					tt.version, tt.os, tt.arch, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetBundleDownloadCommands(t *testing.T) {
+	// getBundleDownloadCommands wraps the download URL in a curl command and appends
+	// the matching tar extraction; the URL routing itself is covered by
+	// TestGetYBAInstallerDownloadURL.
+	folder, commands := getBundleDownloadCommands("2.25.0.0-b300", "linux", "x86_64")
+	if folder != "yba_installer_full-2.25.0.0-b300" {
+		t.Errorf("folder = %q", folder)
+	}
+	if len(commands) != 2 {
+		t.Fatalf("expected 2 commands (curl + tar), got %d: %v", len(commands), commands)
+	}
+	wantCurl := "curl -O " + getYBAInstallerDownloadURL("2.25.0.0-b300", "linux", "x86_64")
+	if commands[0] != wantCurl {
+		t.Errorf("curl command = %q, expected %q", commands[0], wantCurl)
+	}
+	if commands[1] != "tar -xf yba_installer_full-2.25.0.0-b300-centos-x86_64.tar.gz" {
+		t.Errorf("tar command = %q", commands[1])
+	}
+}
+
+func TestGetInstallCommandsWithConfig(t *testing.T) {
+	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", true, nil)
+	// Expected order: curl, tar, license add, mv settings.yml, install
+	if len(cmds) != 5 {
+		t.Fatalf("expected 5 commands when config=true, got %d: %v", len(cmds), cmds)
+	}
+	if !strings.Contains(cmds[3], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
+		t.Errorf("expected settings move at index 3, got %q", cmds[3])
+	}
+	if !strings.Contains(cmds[4], "yba-ctl install -f") {
+		t.Errorf("expected install command at index 4, got %q", cmds[4])
+	}
+}
+
+func TestGetInstallCommandsSkipPreflight(t *testing.T) {
+	tests := []struct {
+		name     string
+		skip     []string
+		expected string
+	}{
+		{"single check", []string{"diskAvailability"}, "-s diskAvailability"},
+		{"multiple checks joined with comma", []string{"a", "b", "c"}, "-s a,b,c"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds := getInstallCommands("2024.1.0.0", "linux", "x86_64", false, &tt.skip)
+			last := cmds[len(cmds)-1]
+			if !strings.Contains(last, tt.expected) {
+				t.Errorf("install command = %q, expected to contain %q", last, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetInstallCommandsNilOrEmptySkipPreflight(t *testing.T) {
+	empty := []string{}
+	for _, skip := range []*[]string{nil, &empty} {
+		cmds := getInstallCommands("2024.1.0.0", "linux", "x86_64", false, skip)
+		last := cmds[len(cmds)-1]
+		if strings.Contains(last, "-s ") {
+			t.Errorf("install command should not contain -s flag, got %q", last)
+		}
+	}
+}
+
+func TestGetReconfigureCommands(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		expectedEnv bool
+	}{
+		{"GA version", "2024.1.0.0-b129", false},
+		{"Pre-release version", "2.25.0.0-b300", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds := getReconfigureCommands(tt.version)
+			if len(cmds) != 2 {
+				t.Fatalf("expected 2 commands, got %d: %v", len(cmds), cmds)
+			}
+			if !strings.Contains(cmds[0], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
+				t.Errorf("expected settings move first, got %q", cmds[0])
+			}
+			if !strings.Contains(cmds[1], "/opt/yba-ctl/yba-ctl reconfigure -f") {
+				t.Errorf("expected reconfigure second, got %q", cmds[1])
+			}
+			hasEnv := strings.Contains(cmds[1], "YBA_MODE=dev")
+			if hasEnv != tt.expectedEnv {
+				t.Errorf("YBA_MODE=dev presence = %v, expected %v in %q",
+					hasEnv, tt.expectedEnv, cmds[1])
+			}
+		})
+	}
+}
+
+func TestGetUpgradeCommands(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		os          string
+		expectedEnv bool
+		bundleOS    string
+	}{
+		{"GA version uses linux bundle, no YBA_MODE", "2024.1.0.0-b129", "linux", false, "linux"},
+		{"Pre-release uses centos bundle, with YBA_MODE", "2.25.0.0-b300", "linux", true, "centos"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds := getUpgradeCommands(tt.version, tt.os, "x86_64", nil)
+			if len(cmds) != 3 {
+				t.Fatalf("expected 3 commands (curl, tar, upgrade), got %d: %v", len(cmds), cmds)
+			}
+			if !strings.Contains(cmds[0], "-"+tt.bundleOS+"-x86_64") {
+				t.Errorf("curl command should reference %q bundle, got %q", tt.bundleOS, cmds[0])
+			}
+			upgrade := cmds[2]
+			if !strings.Contains(upgrade, "yba-ctl upgrade -f") {
+				t.Errorf("expected upgrade command, got %q", upgrade)
+			}
+			hasEnv := strings.Contains(upgrade, "YBA_MODE=dev")
+			if hasEnv != tt.expectedEnv {
+				t.Errorf("YBA_MODE=dev presence = %v, expected %v in %q",
+					hasEnv, tt.expectedEnv, upgrade)
+			}
+		})
+	}
+}
+
+func TestYbaCtlSudo(t *testing.T) {
+	if got := ybaCtlSudo("2024.1.0.0-b129"); got != "sudo" {
+		t.Errorf("ybaCtlSudo(GA) = %q, expected %q", got, "sudo")
+	}
+	if got := ybaCtlSudo("2.25.0.0-b300"); got != "sudo YBA_MODE=dev" {
+		t.Errorf("ybaCtlSudo(pre-release) = %q, expected %q", got, "sudo YBA_MODE=dev")
+	}
+}
+
+func TestGetAddLicenseCommandFormat(t *testing.T) {
+	if got := getAddLicenseCommand("2024.1.0.0-b129", "myfolder"); got !=
+		"sudo ./myfolder/yba-ctl license add -l /tmp/license.lic" {
+		t.Errorf("GA license command = %q", got)
+	}
+	if got := getAddLicenseCommand("2.25.0.0-b300", "myfolder"); got !=
+		"sudo YBA_MODE=dev ./myfolder/yba-ctl license add -l /tmp/license.lic" {
+		t.Errorf("pre-release license command = %q", got)
+	}
+}
+
+func TestGetInstallCommandsPreRelease(t *testing.T) {
+	// Pre-release install pulls the centos bundle from releases.yugabyte.com and
+	// runs yba-ctl in dev mode. Expected order: curl, tar, license add, install.
+	cmds := getInstallCommands("2.31.0.0-b14", "linux", "x86_64", false, nil)
+	if len(cmds) != 4 {
+		t.Fatalf("expected 4 commands when config=false, got %d: %v", len(cmds), cmds)
+	}
+	if !strings.HasPrefix(cmds[0],
+		"curl -O https://releases.yugabyte.com/2.31.0.0-b14/"+
+			"yba_installer_full-2.31.0.0-b14-centos-x86_64") {
+		t.Errorf("curl command = %q", cmds[0])
+	}
+	if !strings.Contains(cmds[2], "YBA_MODE=dev") ||
+		!strings.Contains(cmds[2], "yba-ctl license add") {
+		t.Errorf("license command = %q", cmds[2])
+	}
+	if !strings.Contains(cmds[3], "YBA_MODE=dev ./") ||
+		!strings.Contains(cmds[3], "yba-ctl install -f") {
+		t.Errorf("install command = %q", cmds[3])
+	}
+}
+
+func TestGetUpgradeCommandsSkipPreflight(t *testing.T) {
+	skip := []string{"diskAvailability", "memoryAvailability"}
+	cmds := getUpgradeCommands("2024.1.0.0", "linux", "x86_64", &skip)
+	last := cmds[len(cmds)-1]
+	if !strings.Contains(last, "-s diskAvailability,memoryAvailability") {
+		t.Errorf("upgrade command should contain joined skip flags, got %q", last)
+	}
+}
+
+func TestGetDeleteCommands(t *testing.T) {
+	tests := []struct {
+		name        string
+		version     string
+		expectedEnv bool
+	}{
+		{"GA version", "2024.1.0.0-b129", false},
+		{"Pre-release version", "2.25.0.0-b300", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmds := getDeleteCommands(tt.version)
+			if len(cmds) != 3 {
+				t.Fatalf("expected 3 commands (clean, rm yugabyte, rm tmp), got %d: %v",
+					len(cmds), cmds)
+			}
+			if !strings.Contains(cmds[0], "/opt/yba-ctl/yba-ctl clean") {
+				t.Errorf("expected clean command first, got %q", cmds[0])
+			}
+			hasEnv := strings.Contains(cmds[0], "YBA_MODE=dev")
+			if hasEnv != tt.expectedEnv {
+				t.Errorf("YBA_MODE=dev presence = %v, expected %v in %q",
+					hasEnv, tt.expectedEnv, cmds[0])
+			}
+			if cmds[1] != "sudo rm -rf /opt/yugabyte" {
+				t.Errorf("expected rm -rf /opt/yugabyte, got %q", cmds[1])
+			}
+			if !strings.Contains(cmds[2], "/tmp/server.crt") ||
+				!strings.Contains(cmds[2], "/tmp/server.key") ||
+				!strings.Contains(cmds[2], "/tmp/license.lic") ||
+				!strings.Contains(cmds[2], "/tmp/settings.yml") {
+				t.Errorf("expected rm of all tmp files, got %q", cmds[2])
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Summary

The provider hard-coded `https://downloads.yugabyte.com/releases` as the YBA installer download source, which only works for GA release versions (`20YY.x`). Pre-release / CI builds (`2.xx`) live on a different host (`releases.yugabyte.com`), use a different path layout (full version including build number), require a different OS bundle qualifier (`centos` instead of `linux`), and need `YBA_MODE=dev` to bypass `yba-ctl`'s strict version-comparison check.

This PR auto-detects the version format and routes the bundle download, the bundle name, and the `yba-ctl` invocations accordingly. GA releases are unchanged.

Closes [PLAT-20663](https://yugabyte.atlassian.net/browse/PLAT-20663).

## Source matrix

| Aspect              | GA release                                                | Pre-release / CI build                                     |
| ------------------- | --------------------------------------------------------- | ---------------------------------------------------------- |
| Version format      | `20YY.x.y.z` (e.g. `2024.1.0.0-b129`, `2025.2.2.2-b11`)   | `2.xx.y.z-bN` (e.g. `2.25.0.0-b300`, `2.31.0.0-b14`)        |
| Base URL            | `https://downloads.yugabyte.com/releases`                 | `https://releases.yugabyte.com`                            |
| Path segment        | `/{version-without-build}/`                               | `/{full-version-with-build}/`                              |
| Bundle OS qualifier | `linux`                                                   | `centos`                                                   |
| `yba-ctl` invocation | plain `sudo ./yba-ctl …`                                  | `sudo YBA_MODE=dev ./yba-ctl …`                            |
| Example bundle      | `yba_installer_full-2024.1.0.0-b129-linux-x86_64.tar.gz`  | `yba_installer_full-2.25.0.0-b300-centos-x86_64.tar.gz`    |

## Implementation

In `internal/installation/resource_yba_installer.go`:

- Added `gaVersionRegex = ^20\d{2}\.` and an exported `IsGAVersion(version string) bool` predicate.
- New constants `GADownloadURL` and `PreReleaseDownloadURL`.
- `ybaCtlSudo(version)` centralizes the invocation prefix — `sudo` for GA, `sudo YBA_MODE=dev` for pre-release. All command builders share it instead of repeating the branch.
- `getYBAInstallerPackageNames` (renamed from `getYBAInstallerPackageString`) rewrites `linux` → `centos` for pre-release versions when constructing the bundle name.
- `getYBAInstallerDownloadURL` is the single source of the tarball URL and selects the base URL and path layout from `IsGAVersion(version)`. GA: `{GADownloadURL}/{version-without-build}/{bundle}.tar.gz`. Pre-release: `{PreReleaseDownloadURL}/{full-version}/{bundle}.tar.gz`.
- `getBundleDownloadCommands` (renamed from the misleadingly named `getYBAInstallerBundle`, which returns commands, not a bundle) wraps that URL in the `curl` + `tar` commands.
- `getAddLicenseCommand`, `getInstallCommands`, `getUpgradeCommands`, `getReconfigureCommands`, and `getDeleteCommands` all build their `yba-ctl` invocation via `ybaCtlSudo(version)`.
- `resourceYBAInstallerUpdate` and `resourceYBAInstallerDelete` now thread `yba_version` (the old version, in `Update`'s case) into the command builders so the right invocation form is chosen.
- Drive-by: replaced the bespoke `getSkipPreflightChecksSubCommand` loop with `strings.Join`. Same output, less code.

## Tests

`internal/installation/resource_yba_installer_test.go` is new. Every pure helper is covered for both GA and pre-release inputs (100% statement coverage on the helpers; the SSH-bound CRUD entry points remain acceptance-test territory):

- `TestIsGAVersion` — version-format classification, including edge cases (empty string, year without trailing dot, pre-2000 year, non-anchored match).
- `TestGetYBAInstallerPackageNames` — bundle-name construction including the `linux` → `centos` rewrite and build-number stripping.
- `TestGetYBAInstallerDownloadURL` — exact tarball URL for GA (build-stripped path) vs pre-release (full-version path), plus `aarch64` to confirm architecture propagation.
- `TestGetBundleDownloadCommands` — the `curl` + `tar` command assembly wraps the URL correctly.
- `TestYbaCtlSudo`, `TestGetAddLicenseCommandFormat` — exact invocation prefix / license command for both code paths.
- `TestGetInstallCommandsWithConfig`, `TestGetInstallCommandsPreRelease`, `TestGetInstallCommandsSkipPreflight`, `TestGetInstallCommandsNilOrEmptySkipPreflight` — install ordering, the pre-release path, skip-preflight flag joining, and the nil/empty boundary.
- `TestGetReconfigureCommands`, `TestGetUpgradeCommands`, `TestGetUpgradeCommandsSkipPreflight`, `TestGetDeleteCommands` — same GA/pre-release matrix for the remaining lifecycle commands.

## Documentation

Documentation is intentionally not updated, as there is no need to expose this functionality to customers.

## Acceptance criteria

- [x] Provider can install YBA from `20YY.x` versions (GA releases) — unchanged code path, regression-tested.
- [x] Provider can install YBA from `2.xx` versions (pre-release / CI builds).
- [x] Version detection logic correctly routes to the appropriate bucket (`TestIsGAVersion`, `TestGetYBAInstallerDownloadURL`).
- [x] Documentation updated to reflect pre-release support.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l internal/` clean
- [x] `make lint` (golangci-lint) — 0 issues
- [x] `go test ./internal/installation/...` all green
- [x] `make documents` regenerates without drift
- [ ] Manual install against a `2.xx` pre-release build on a real YBA host
- [ ] Manual install against a `20YY.x` GA release on a real YBA host (regression check)


[PLAT-20663]: https://yugabyte.atlassian.net/browse/PLAT-20663?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
