### PR TITLE
[PLAT-20607] Support inline content attributes in yba_installer

### DIFF
--- a/docs/resources/installer.md
+++ b/docs/resources/installer.md
@@ -18,7 +18,25 @@ provider "yba" {
   host  = "<host-ip-address>"
 }
 
+# Pass values that are already strings inside Terraform directly to the
+# resource - no temporary files are required on the local filesystem.
 resource "yba_installer" "install" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "<ip-of-yba-node-for-ssh-commands>"
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key      = var.ssh_private_key
+  yba_license          = var.yba_license_content
+  application_settings = local.yba_ctl_yaml
+  tls_certificate      = tls_self_signed_cert.yba.cert_pem
+  tls_key              = tls_private_key.yba.private_key_pem
+
+  yba_version = "<YugabyteDB Anywhere-version-with-build-number>"
+}
+
+# Alternatively, point each attribute at a local file. The file-based
+# attributes remain supported for backward compatibility.
+resource "yba_installer" "install_from_files" {
   provider                  = yba.unauthenticated
   ssh_host_ip               = "<ip-of-yba-node-for-ssh-commands>"
   ssh_user                  = "<ssh-user>"
@@ -29,19 +47,25 @@ resource "yba_installer" "install" {
 }
 ```
 
+### Inline content vs. file paths
+
+Each input can be supplied either as an inline string or as a path to a local file. Inline (content-based) attributes are marked sensitive and are mutually exclusive with their file-based counterparts.
+
+| Inline content       | File path                   |
+| -------------------- | --------------------------- |
+| `ssh_private_key`    | `ssh_private_key_file_path` |
+| `application_settings` | `application_settings_file` |
+| `yba_license`        | `yba_license_file`          |
+| `tls_certificate`    | `tls_certificate_file`      |
+| `tls_key`            | `tls_key_file`              |
+
+Use the inline form when the value is already available inside Terraform (for example as the output of a `tls_private_key` resource or a Terraform variable). This avoids the need to materialise temporary files via `local_sensitive_file` just to satisfy the provider, and keeps sensitive material off the local filesystem.
+
 To upgrade YugabyteDB Anywhere version, change *yba_version* to the desired version and run *terraform apply*. In case the upgarde fails mid-way, taint the resource in the *terraform.tfstate* file and rerun the *apply* command.
 
--> **Note:** If modifications are made in the configuration file contents, set *reconfigure* to *true* for the changes to be acknowledged.
+-> **Note:** Changes to the inline `application_settings`, `tls_certificate`, or `tls_key` attributes (or their file-based equivalents) automatically trigger a reconfiguration on the next apply. The `reconfigure = true` flag is only needed when forcing reconfiguration without any tracked input change.
 
 -> **Note:** The paths for server certs and keys on the YugabyteDB Anywhere host are **/tmp/server.crt** and **/tmp/server.key** respectively, which need to be set in the configuration file before installation for proper usage.
-
-To change any of the following file contents -
-
-1. License File (yba_license_file)
-2. TLS Certificate File (tls_certificate_file)
-3. TLS Key File (tls_key_file)
-
-Change the path on the corresponding resource field and run *terraform apply* for the new files to be uploaded.
 
 For further details on configuration and host requirements, refer to [Install YBA software using YBA Installer](https://docs.yugabyte.com/stable/yugabyte-platform/install-yugabyte-platform/install-software/installer/).
 
@@ -51,21 +75,26 @@ For further details on configuration and host requirements, refer to [Install YB
 ### Required
 
 - `ssh_host_ip` (String) IP address of VM for SSH. Typically same as public_ip or private_ip.
-- `ssh_private_key_file_path` (String) Path to file containing the private key to use for ssh commands.
 - `ssh_user` (String) User with sudo access to use for ssh commands.
-- `yba_license_file` (String) YugabyteDB Anywhere license file used for installation using YBA installer.
 - `yba_version` (String) Version of YugabyteDB Anywhere to be installed.
 
 ### Optional
 
-- `application_settings_file` (String) Application settings file to configure YugabyteDB Anywhere. If left empty, the [default configuration](https://github.com/yugabyte/terraform-provider-yba/tree/main/acctest/resources/yba-ctl.yml) would be used for the application.
+- `application_settings` (String, Sensitive) Inline application settings contents used to configure YugabyteDB Anywhere. If left empty, the [default configuration](https://github.com/yugabyte/terraform-provider-yba/tree/main/acctest/resources/yba-ctl.yml) would be used.
+- `application_settings_file` (String) Path to an application settings file to configure YugabyteDB Anywhere. If left empty, the [default configuration](https://github.com/yugabyte/terraform-provider-yba/tree/main/acctest/resources/yba-ctl.yml) would be used. Conflicts with `application_settings`.
 - `host_architecture` (String) Architecture of the host Virtual Machine. Default is x86_64.
 - `host_os` (String) Operating System of the host Virtual Machine. Default is linux.
-- `reconfigure` (Boolean) Set to true for reconfiguration (If the contents of application_settings_file have been modified).
+- `reconfigure` (Boolean) Force a reconfiguration on the next apply, even when no other tracked attribute has changed. Content changes to `application_settings`, `tls_certificate`, or `tls_key` already trigger reconfiguration automatically.
 - `skip_preflight_checks` (List of String) Check names to be skipped during preflight check.
+- `ssh_private_key` (String, Sensitive) Contents of the private key to use for ssh commands. Use this instead of `ssh_private_key_file_path` to pass the key directly without writing it to a local file.
+- `ssh_private_key_file_path` (String) Path to file containing the private key to use for ssh commands. Conflicts with `ssh_private_key`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
-- `tls_certificate_file` (String) TLS certificate used to configure HTTPS. Ensure yba_application_settings file has *server_cert_path* set to /tmp/server.crt
-- `tls_key_file` (String) TLS key used to configure HTTPS. Ensure yba_application_settings file has *server_key_path* set to /tmp/server.key
+- `tls_certificate` (String, Sensitive) Inline TLS certificate contents used to configure HTTPS. Ensure the application settings have *server_cert_path* set to /tmp/server.crt.
+- `tls_certificate_file` (String) Path to a TLS certificate file used to configure HTTPS. Ensure the application settings have *server_cert_path* set to /tmp/server.crt. Conflicts with `tls_certificate`.
+- `tls_key` (String, Sensitive) Inline TLS key contents used to configure HTTPS. Ensure the application settings have *server_key_path* set to /tmp/server.key.
+- `tls_key_file` (String) Path to a TLS key file used to configure HTTPS. Ensure the application settings have *server_key_path* set to /tmp/server.key. Conflicts with `tls_key`.
+- `yba_license` (String, Sensitive) Inline YugabyteDB Anywhere license contents used for installation. Use this instead of `yba_license_file` to pass the license without writing it to a local file.
+- `yba_license_file` (String) Path to a YugabyteDB Anywhere license file used for installation. Conflicts with `yba_license`.
 
 ### Read-Only
 

--- a/examples/resources/yba_installer/resource.tf
+++ b/examples/resources/yba_installer/resource.tf
@@ -3,7 +3,25 @@ provider "yba" {
   host  = "<host-ip-address>"
 }
 
+# Pass values that are already strings inside Terraform directly to the
+# resource - no temporary files are required on the local filesystem.
 resource "yba_installer" "install" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "<ip-of-yba-node-for-ssh-commands>"
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key      = var.ssh_private_key
+  yba_license          = var.yba_license_content
+  application_settings = local.yba_ctl_yaml
+  tls_certificate      = tls_self_signed_cert.yba.cert_pem
+  tls_key              = tls_private_key.yba.private_key_pem
+
+  yba_version = "<YugabyteDB Anywhere-version-with-build-number>"
+}
+
+# Alternatively, point each attribute at a local file. The file-based
+# attributes remain supported for backward compatibility.
+resource "yba_installer" "install_from_files" {
   provider                  = yba.unauthenticated
   ssh_host_ip               = "<ip-of-yba-node-for-ssh-commands>"
   ssh_user                  = "<ssh-user>"

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -29,26 +30,154 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"golang.org/x/exp/maps"
+	"golang.org/x/crypto/ssh"
 
 	"github.com/yugabyte/terraform-provider-yba/internal/utils"
 )
 
+// installerFileSpec describes one logical input that the YBA installer
+// resource needs to upload to the remote host. Each spec exposes both a
+// file-path attribute and a content attribute. Either may be set; the
+// content attribute takes precedence when both are populated (the schema
+// also marks them as conflicting so this is normally rejected by
+// Terraform up-front).
+type installerFileSpec struct {
+	// fileAttr is the attribute that accepts a path to a local file.
+	fileAttr string
+	// contentAttr is the attribute that accepts the file contents
+	// directly as a string.
+	contentAttr string
+	// remotePath is where the contents are written on the remote host.
+	remotePath string
+}
+
 var (
-	reconfigurationYBAInstallerFiles = map[string]string{
-		"tls_certificate_file":      "/tmp/server.crt",
-		"tls_key_file":              "/tmp/server.key",
-		"application_settings_file": "/tmp/settings.yml",
+	tlsCertificateSpec = installerFileSpec{
+		fileAttr:    "tls_certificate_file",
+		contentAttr: "tls_certificate",
+		remotePath:  "/tmp/server.crt",
 	}
-	licenseYBAInstallerFiles = map[string]string{
-		"yba_license_file": "/tmp/license.lic",
+	tlsKeySpec = installerFileSpec{
+		fileAttr:    "tls_key_file",
+		contentAttr: "tls_key",
+		remotePath:  "/tmp/server.key",
+	}
+	applicationSettingsSpec = installerFileSpec{
+		fileAttr:    "application_settings_file",
+		contentAttr: "application_settings",
+		remotePath:  "/tmp/settings.yml",
+	}
+	licenseSpec = installerFileSpec{
+		fileAttr:    "yba_license_file",
+		contentAttr: "yba_license",
+		remotePath:  "/tmp/license.lic",
+	}
+	sshPrivateKeySpec = installerFileSpec{
+		fileAttr:    "ssh_private_key_file_path",
+		contentAttr: "ssh_private_key",
+		// ssh_private_key is consumed locally (to authenticate) and is
+		// not transferred to the remote host. remotePath is unused.
 	}
 )
 
-func getInstallationFiles() map[string]string {
-	installationYBAInstallerFiles := reconfigurationYBAInstallerFiles
-	maps.Copy(installationYBAInstallerFiles, licenseYBAInstallerFiles)
-	return installationYBAInstallerFiles
+// reconfigurationYBAInstallerSpecs lists inputs that participate in a
+// reconfigure cycle (their values are written to /tmp/* on the remote
+// host before yba-ctl reconfigure runs).
+func reconfigurationYBAInstallerSpecs() []installerFileSpec {
+	return []installerFileSpec{
+		tlsCertificateSpec,
+		tlsKeySpec,
+		applicationSettingsSpec,
+	}
+}
+
+// licenseYBAInstallerSpecs lists inputs that are uploaded as part of a
+// license-update flow.
+func licenseYBAInstallerSpecs() []installerFileSpec {
+	return []installerFileSpec{
+		licenseSpec,
+	}
+}
+
+// installationYBAInstallerSpecs lists every spec that may need to be
+// uploaded during a fresh install.
+func installationYBAInstallerSpecs() []installerFileSpec {
+	specs := make([]installerFileSpec, 0,
+		len(reconfigurationYBAInstallerSpecs())+len(licenseYBAInstallerSpecs()))
+	specs = append(specs, reconfigurationYBAInstallerSpecs()...)
+	specs = append(specs, licenseYBAInstallerSpecs()...)
+	return specs
+}
+
+// resolveInstallerInput returns the content for a given installer input,
+// preferring the inline content attribute when set and falling back to
+// reading the file pointed to by the file-path attribute. An empty
+// string with a nil error is returned when neither attribute is set
+// (callers should treat that as "input not provided").
+func resolveInstallerInput(d *schema.ResourceData, spec installerFileSpec) (string, error) {
+	if spec.contentAttr != "" {
+		if v, ok := d.GetOk(spec.contentAttr); ok {
+			content := v.(string)
+			if content != "" {
+				return content, nil
+			}
+		}
+	}
+	if spec.fileAttr != "" {
+		if v, ok := d.GetOk(spec.fileAttr); ok {
+			path := v.(string)
+			if path != "" {
+				data, err := os.ReadFile(path)
+				if err != nil {
+					return "", fmt.Errorf("failed reading data from %s: %w", path, err)
+				}
+				return string(data), nil
+			}
+		}
+	}
+	return "", nil
+}
+
+// changeDetector is the minimal surface area needed by
+// installerInputHasChange. Both *schema.ResourceData and
+// *schema.ResourceDiff satisfy it.
+type changeDetector interface {
+	HasChange(key string) bool
+}
+
+// inputReader is the minimal surface area needed by
+// installerInputProvided. Both *schema.ResourceData and
+// *schema.ResourceDiff satisfy it.
+type inputReader interface {
+	GetOk(key string) (interface{}, bool)
+}
+
+// installerInputHasChange returns true if either of the attributes for
+// the given spec has changed.
+func installerInputHasChange(d changeDetector, spec installerFileSpec) bool {
+	if spec.contentAttr != "" && d.HasChange(spec.contentAttr) {
+		return true
+	}
+	if spec.fileAttr != "" && d.HasChange(spec.fileAttr) {
+		return true
+	}
+	return false
+}
+
+// installerInputProvided returns true if either attribute for the spec
+// is set to a non-empty value.
+func installerInputProvided(d inputReader, spec installerFileSpec) bool {
+	if spec.contentAttr != "" {
+		if v, ok := d.GetOk(spec.contentAttr); ok && v.(string) != "" {
+			return true
+		}
+	}
+	if spec.fileAttr != "" {
+		if v, ok := d.GetOk(spec.fileAttr); ok && v.(string) != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // ResourceYBAInstaller handles installation of YugabyteDB Anywhere using YBA installer
@@ -103,9 +232,25 @@ func ResourceYBAInstaller() *schema.Resource {
 			},
 			"ssh_private_key_file_path": {
 				Type:     schema.TypeString,
-				Required: true,
+				Optional: true,
+				ExactlyOneOf: []string{
+					"ssh_private_key_file_path",
+					"ssh_private_key",
+				},
+				ConflictsWith: []string{"ssh_private_key"},
 				Description: "Path to file containing the private key to use for ssh " +
-					"commands.",
+					"commands. Conflicts with `ssh_private_key`.",
+			},
+			"ssh_private_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				ConflictsWith: []string{
+					"ssh_private_key_file_path",
+				},
+				Description: "Contents of the private key to use for ssh commands. " +
+					"Use this instead of `ssh_private_key_file_path` to pass the key " +
+					"directly without writing it to a local file.",
 			},
 			"ssh_user": {
 				Type:        schema.TypeString,
@@ -116,33 +261,84 @@ func ResourceYBAInstaller() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 				// change should trigger yba-ctl reconfigure
-				RequiredWith: []string{"tls_key_file"},
-				Description: "TLS certificate used to configure HTTPS. Ensure " +
-					"yba_application_settings file has *server_cert_path* set to /tmp/server.crt",
+				ConflictsWith: []string{"tls_certificate"},
+				Description: "Path to a TLS certificate file used to configure HTTPS. " +
+					"Ensure the application settings have *server_cert_path* set to " +
+					"/tmp/server.crt. Conflicts with `tls_certificate`.",
+			},
+			"tls_certificate": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				// change should trigger yba-ctl reconfigure
+				ConflictsWith: []string{"tls_certificate_file"},
+				Description: "Inline TLS certificate contents used to configure HTTPS. " +
+					"Ensure the application settings have *server_cert_path* set to " +
+					"/tmp/server.crt.",
 			},
 			"tls_key_file": {
 				Type:     schema.TypeString,
 				Optional: true,
 				// change should trigger yba-ctl reconfigure
-				RequiredWith: []string{"tls_certificate_file"},
-				Description: "TLS key used to configure HTTPS. Ensure " +
-					"yba_application_settings file has *server_key_path* set to /tmp/server.key",
+				ConflictsWith: []string{"tls_key"},
+				Description: "Path to a TLS key file used to configure HTTPS. Ensure " +
+					"the application settings have *server_key_path* set to " +
+					"/tmp/server.key. Conflicts with `tls_key`.",
+			},
+			"tls_key": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				// change should trigger yba-ctl reconfigure
+				ConflictsWith: []string{"tls_key_file"},
+				Description: "Inline TLS key contents used to configure HTTPS. Ensure " +
+					"the application settings have *server_key_path* set to " +
+					"/tmp/server.key.",
 			},
 			"yba_license_file": {
 				Type:     schema.TypeString,
-				Required: true,
-				Description: "YugabyteDB Anywhere license file used for installation using " +
-					"YBA installer.",
+				Optional: true,
+				ExactlyOneOf: []string{
+					"yba_license_file",
+					"yba_license",
+				},
+				ConflictsWith: []string{"yba_license"},
+				Description: "Path to a YugabyteDB Anywhere license file used for " +
+					"installation. Conflicts with `yba_license`.",
+			},
+			"yba_license": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				ConflictsWith: []string{
+					"yba_license_file",
+				},
+				Description: "Inline YugabyteDB Anywhere license contents used for " +
+					"installation. Use this instead of `yba_license_file` to pass " +
+					"the license without writing it to a local file.",
 			},
 			"application_settings_file": {
 				Type:     schema.TypeString,
 				Optional: true,
 				// Change in this should trigger yba-ctl reconfigure
-				Description: "Application settings file to configure YugabyteDB Anywhere. " +
-					"If left empty, the [default configuration]" +
+				ConflictsWith: []string{"application_settings"},
+				Description: "Path to an application settings file to configure " +
+					"YugabyteDB Anywhere. If left empty, the [default configuration]" +
 					"(https://github.com/yugabyte/terraform-provider-yba/tree/main" +
 					"/acctest/resources/yba-ctl.yml)" +
-					" would be used for the application.",
+					" would be used. Conflicts with `application_settings`.",
+			},
+			"application_settings": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+				// Change in this should trigger yba-ctl reconfigure
+				ConflictsWith: []string{"application_settings_file"},
+				Description: "Inline application settings contents used to configure " +
+					"YugabyteDB Anywhere. If left empty, the [default configuration]" +
+					"(https://github.com/yugabyte/terraform-provider-yba/tree/main" +
+					"/acctest/resources/yba-ctl.yml)" +
+					" would be used.",
 			},
 			"reconfigure": {
 				Type:     schema.TypeBool,
@@ -150,8 +346,10 @@ func ResourceYBAInstaller() *schema.Resource {
 				Default:  false,
 				// True should trigger yba-ctl reconfigure
 				// if the contents of application_settings_file have been modified
-				Description: "Set to true for reconfiguration (If the contents of " +
-					"application_settings_file have been modified).",
+				Description: "Force a reconfiguration on the next apply, even when " +
+					"no other tracked attribute has changed. Content changes to " +
+					"`application_settings`, `tls_certificate`, or `tls_key` " +
+					"already trigger reconfiguration automatically.",
 			},
 			"skip_preflight_checks": {
 				Type:     schema.TypeList,
@@ -165,61 +363,102 @@ func ResourceYBAInstaller() *schema.Resource {
 	}
 }
 
+// validateInstallerFileAttr returns a CustomizeDiff function that
+// confirms a file-path attribute points at a real file (only when the
+// attribute is non-empty - empty values are valid because the user may
+// be supplying contents via the corresponding content attribute).
+func validateInstallerFileAttr(attr string) schema.CustomizeDiffFunc {
+	return customdiff.ValidateValue(attr, func(ctx context.Context, value,
+		meta interface{}) error {
+		name, _ := value.(string)
+		if name == "" {
+			return nil
+		}
+		return utils.FileExist(name)
+	})
+}
+
 func resourceYBAInstallerDiff() schema.CustomizeDiffFunc {
 	return customdiff.All(
-		customdiff.ValidateValue("tls_certificate_file", func(ctx context.Context, value,
-			meta interface{}) error {
-			if value.(string) != "" {
-				name := value.(string)
-				if err := utils.FileExist(name); err != nil {
-					return err
-				}
+		validateInstallerFileAttr("tls_certificate_file"),
+		validateInstallerFileAttr("tls_key_file"),
+		validateInstallerFileAttr("yba_license_file"),
+		validateInstallerFileAttr("application_settings_file"),
+		validateInstallerFileAttr("ssh_private_key_file_path"),
+		// TLS cert and key must be supplied together. Either side may
+		// be provided through the file-path or the inline content
+		// attribute.
+		func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
+			certProvided := installerInputProvided(d, tlsCertificateSpec)
+			keyProvided := installerInputProvided(d, tlsKeySpec)
+			if certProvided != keyProvided {
+				return errors.New(
+					"tls_certificate / tls_certificate_file and tls_key / " +
+						"tls_key_file must be set together",
+				)
 			}
 			return nil
-		}),
-		customdiff.ValidateValue("tls_key_file", func(ctx context.Context, value,
-			meta interface{}) error {
-			if value.(string) != "" {
-				name := value.(string)
-				if err := utils.FileExist(name); err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-		customdiff.ValidateValue("yba_license_file", func(ctx context.Context, value,
-			meta interface{}) error {
-			name := value.(string)
-			return utils.FileExist(name)
-		}),
-		customdiff.ValidateValue("application_settings_file", func(ctx context.Context, value,
-			meta interface{}) error {
-			if value.(string) != "" {
-				name := value.(string)
-				if err := utils.FileExist(name); err != nil {
-					return err
-				}
-			}
-			return nil
-		}),
-		customdiff.ValidateValue("ssh_private_key_file_path", func(ctx context.Context, value,
-			meta interface{}) error {
-			name := value.(string)
-			return utils.FileExist(name)
-		}),
+		},
 		customdiff.IfValue("reconfigure",
 			func(ctx context.Context, value, meta interface{}) bool {
 				return value.(bool)
 			},
 			func(ctx context.Context, d *schema.ResourceDiff, meta interface{}) error {
-				applicationSettingsFile := d.Get("application_settings_file").(string)
-				if applicationSettingsFile == "" {
-					return errors.New("Cannot reconfigure YBA Installer with empty " +
-						"application_settings_file file")
+				if !installerInputProvided(d, applicationSettingsSpec) {
+					return errEmptyApplicationSettings
 				}
 				return nil
 			}),
 	)
+}
+
+// errEmptyApplicationSettings is returned when a reconfigure is
+// requested but neither application_settings nor
+// application_settings_file is set.
+var errEmptyApplicationSettings = errors.New(
+	"Cannot reconfigure YBA Installer with empty application_settings " +
+		"(or application_settings_file)",
+)
+
+// resolveSSHPrivateKey returns the SSH private key contents either from
+// the inline `ssh_private_key` attribute or by reading the file pointed
+// to by `ssh_private_key_file_path`.
+func resolveSSHPrivateKey(d *schema.ResourceData) (string, error) {
+	content, err := resolveInstallerInput(d, sshPrivateKeySpec)
+	if err != nil {
+		return "", err
+	}
+	if content == "" {
+		return "", errors.New("ssh_private_key or ssh_private_key_file_path must be set")
+	}
+	return content, nil
+}
+
+// uploadInstallerInputs resolves and uploads each given input to the
+// remote host. Inputs that are not set (neither file path nor content)
+// are skipped.
+func uploadInstallerInputs(
+	ctx context.Context,
+	sshClient *ssh.Client,
+	d *schema.ResourceData,
+	specs []installerFileSpec,
+) error {
+	for _, spec := range specs {
+		if spec.remotePath == "" {
+			continue
+		}
+		content, err := resolveInstallerInput(d, spec)
+		if err != nil {
+			return err
+		}
+		if content == "" {
+			continue
+		}
+		if err := scpContent(ctx, sshClient, content, spec.remotePath); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func resourceYBAInstallerCreate(
@@ -230,42 +469,37 @@ func resourceYBAInstallerCreate(
 
 	hostIPForSSH := d.Get("ssh_host_ip").(string)
 	user := d.Get("ssh_user").(string)
-	pk, err := utils.ReadSSHPrivateKey(d.Get("ssh_private_key_file_path").(string))
+	pk, err := resolveSSHPrivateKey(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	sshClient, err := waitForIP(ctx, user, hostIPForSSH, *pk, d.Timeout(schema.TimeoutCreate))
+	sshClient, err := waitForIP(ctx, user, hostIPForSSH, pk, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		tflog.Error(ctx, "Timeout: Couldn't connect to YugabyteDB Anywhere host")
 		return diag.FromErr(err)
 	}
 	defer func() { _ = sshClient.Close() }()
 
-	for key, remote := range getInstallationFiles() {
-		local := d.Get(key).(string)
-		if local == "" {
-			continue
-		}
-		err = scpFile(ctx, sshClient, local, remote)
-		if err != nil {
-			tflog.Error(ctx, "Error occurred while transferring files required for installation")
-			return diag.FromErr(err)
-		}
+	if err := uploadInstallerInputs(
+		ctx,
+		sshClient,
+		d,
+		installationYBAInstallerSpecs(),
+	); err != nil {
+		tflog.Error(ctx, "Error occurred while transferring files required for installation")
+		return diag.FromErr(err)
 	}
 
 	ybaVersion := d.Get("yba_version").(string)
 	hostOS := d.Get("host_os").(string)
 	hostArch := d.Get("host_architecture").(string)
-	configExists := false
 	skipPreflight := d.Get("skip_preflight_checks")
 	var skipPreflightChecksList *[]string
 	if skipPreflight != nil {
 		skipPreflightChecksList = utils.StringSlice(d.Get("skip_preflight_checks").([]interface{}))
 	}
-	if d.Get("application_settings_file").(string) != "" {
-		configExists = true
-	}
+	configExists := installerInputProvided(d, applicationSettingsSpec)
 
 	for _, cmd := range getInstallCommands(ybaVersion, hostOS, hostArch, configExists,
 		skipPreflightChecksList) {
@@ -300,12 +534,12 @@ func resourceYBAInstallerUpdate(
 
 	hostIPForSSH := d.Get("ssh_host_ip").(string)
 	user := d.Get("ssh_user").(string)
-	pk, err := utils.ReadSSHPrivateKey(d.Get("ssh_private_key_file_path").(string))
-	skipPreflightChecksList := utils.StringSlice(d.Get("skip_preflight_checks").([]interface{}))
+	pk, err := resolveSSHPrivateKey(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	sshClient, err := waitForIP(ctx, user, hostIPForSSH, *pk, d.Timeout(schema.TimeoutCreate))
+	skipPreflightChecksList := utils.StringSlice(d.Get("skip_preflight_checks").([]interface{}))
+	sshClient, err := waitForIP(ctx, user, hostIPForSSH, pk, d.Timeout(schema.TimeoutCreate))
 	if err != nil {
 		tflog.Error(ctx, "Timeout: Couldn't connect to YugabyteDB Anywhere host")
 		return diag.FromErr(err)
@@ -325,43 +559,30 @@ func resourceYBAInstallerUpdate(
 
 	commands := make([]string, 0)
 
-	if d.HasChange("yba_license_file") {
-		for key, remote := range licenseYBAInstallerFiles {
-			local := d.Get(key).(string)
-			if local == "" {
-				continue
-			}
-			err = scpFile(ctx, sshClient, local, remote)
-			if err != nil {
-				tflog.Error(ctx, "Error occurred while transferring files required for "+
-					"updating license")
-				return diag.FromErr(err)
-			}
+	if installerInputHasChange(d, licenseSpec) {
+		if err := uploadInstallerInputs(ctx, sshClient, d, licenseYBAInstallerSpecs()); err != nil {
+			tflog.Error(ctx, "Error occurred while transferring files required for "+
+				"updating license")
+			return diag.FromErr(err)
 		}
-
 		folder, _, _ := getYBAInstallerPackageString(oldVersion, hostOS, hostArch)
 		commands = append(commands, getAddLicenseCommands(folder))
 	}
 
-	if d.Get("reconfigure").(bool) || d.HasChange("application_settings_file") ||
-		d.HasChange("tls_certificate_file") || d.HasChange("tls_key_file") {
-		applicationSettingsFile := d.Get("application_settings_file").(string)
-		if applicationSettingsFile == "" {
-			return diag.FromErr(errors.New(
-				"cannot reconfigure YBA Installer with empty application_settings_file file",
-			))
+	reconfigureRequested := d.Get("reconfigure").(bool)
+	contentChanged := installerInputHasChange(d, applicationSettingsSpec) ||
+		installerInputHasChange(d, tlsCertificateSpec) ||
+		installerInputHasChange(d, tlsKeySpec)
+	if reconfigureRequested || contentChanged {
+		if !installerInputProvided(d, applicationSettingsSpec) {
+			return diag.FromErr(errEmptyApplicationSettings)
 		}
-		for key, remote := range reconfigurationYBAInstallerFiles {
-			local := d.Get(key).(string)
-			if local == "" {
-				continue
-			}
-			err = scpFile(ctx, sshClient, local, remote)
-			if err != nil {
-				tflog.Error(ctx, "Error occurred while transferring files required for "+
-					"reconfiguration")
-				return diag.FromErr(err)
-			}
+		if err := uploadInstallerInputs(
+			ctx, sshClient, d, reconfigurationYBAInstallerSpecs(),
+		); err != nil {
+			tflog.Error(ctx, "Error occurred while transferring files required for "+
+				"reconfiguration")
+			return diag.FromErr(err)
 		}
 		commands = append(commands, getReconfigureCommands()...)
 	}
@@ -393,12 +614,12 @@ func resourceYBAInstallerDelete(
 
 	hostIPForSSH := d.Get("ssh_host_ip").(string)
 	user := d.Get("ssh_user").(string)
-	pk, err := utils.ReadSSHPrivateKey(d.Get("ssh_private_key_file_path").(string))
+	pk, err := resolveSSHPrivateKey(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	sshClient, err := newSSHClient(user, hostIPForSSH, *pk)
+	sshClient, err := newSSHClient(user, hostIPForSSH, pk)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -1,0 +1,281 @@
+// Licensed to YugabyteDB, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Mozilla License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://mozilla.org/MPL/2.0/.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package installation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+)
+
+// newInstallerData builds a *schema.ResourceData from the real resource
+// schema so the tests exercise the same GetOk semantics the runtime sees.
+func newInstallerData(t *testing.T, raw map[string]interface{}) *schema.ResourceData {
+	t.Helper()
+	return schema.TestResourceDataRaw(t, ResourceYBAInstaller().Schema, raw)
+}
+
+// TestSchemaIsValid guards the schema wiring (ConflictsWith / ExactlyOneOf
+// references, types, etc.). A typo in an attribute name referenced by
+// ConflictsWith would only surface at provider start otherwise.
+func TestSchemaIsValid(t *testing.T) {
+	if err := ResourceYBAInstaller().InternalValidate(nil, true); err != nil {
+		t.Fatalf("installer schema failed InternalValidate: %v", err)
+	}
+}
+
+// TestResolveInstallerInput covers the inline-vs-file precedence and the
+// "neither set" case for the content/file pair.
+func TestResolveInstallerInput(t *testing.T) {
+	dir := t.TempDir()
+	licPath := filepath.Join(dir, "license.lic")
+	if err := os.WriteFile(licPath, []byte("from-file"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		raw     map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "inline content used when only inline is set",
+			raw: map[string]interface{}{
+				"yba_license": "inline-license",
+			},
+			want: "inline-license",
+		},
+		{
+			// ConflictsWith normally prevents both being set, but the
+			// resolver still documents inline-over-file precedence.
+			name: "inline content takes precedence over file",
+			raw: map[string]interface{}{
+				"yba_license":      "inline-license",
+				"yba_license_file": licPath,
+			},
+			want: "inline-license",
+		},
+		{
+			name: "falls back to file when no inline content",
+			raw: map[string]interface{}{
+				"yba_license_file": licPath,
+			},
+			want: "from-file",
+		},
+		{
+			name: "neither set returns empty without error",
+			raw:  map[string]interface{}{},
+			want: "",
+		},
+		{
+			name: "missing file surfaces an error",
+			raw: map[string]interface{}{
+				"yba_license_file": filepath.Join(dir, "does-not-exist.lic"),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newInstallerData(t, tt.raw)
+			got, err := resolveInstallerInput(d, licenseSpec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got content %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestResolveSSHPrivateKey checks that either form satisfies the SSH key,
+// and that supplying neither is an error.
+func TestResolveSSHPrivateKey(t *testing.T) {
+	dir := t.TempDir()
+	keyPath := filepath.Join(dir, "id_rsa")
+	if err := os.WriteFile(keyPath, []byte("key-from-file"), 0o600); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		raw     map[string]interface{}
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "inline key",
+			raw:  map[string]interface{}{"ssh_private_key": "inline-key"},
+			want: "inline-key",
+		},
+		{
+			name: "file key",
+			raw:  map[string]interface{}{"ssh_private_key_file_path": keyPath},
+			want: "key-from-file",
+		},
+		{
+			name:    "neither is an error",
+			raw:     map[string]interface{}{},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newInstallerData(t, tt.raw)
+			got, err := resolveSSHPrivateKey(d)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInstallerInputProvided checks the "is this input set in either form"
+// predicate used by CustomizeDiff and the reconfigure flow.
+func TestInstallerInputProvided(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  map[string]interface{}
+		spec installerFileSpec
+		want bool
+	}{
+		{
+			name: "inline form provided",
+			raw:  map[string]interface{}{"tls_certificate": "cert"},
+			spec: tlsCertificateSpec,
+			want: true,
+		},
+		{
+			name: "file form provided",
+			raw:  map[string]interface{}{"tls_certificate_file": "/tmp/c.crt"},
+			spec: tlsCertificateSpec,
+			want: true,
+		},
+		{
+			name: "neither provided",
+			raw:  map[string]interface{}{},
+			spec: tlsCertificateSpec,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := newInstallerData(t, tt.raw)
+			if got := installerInputProvided(d, tt.spec); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// fakeChangeDetector lets us drive installerInputHasChange without a real
+// plan diff; *schema.ResourceData / *schema.ResourceDiff also satisfy the
+// changeDetector interface in production.
+type fakeChangeDetector struct {
+	changed map[string]bool
+}
+
+func (f fakeChangeDetector) HasChange(key string) bool { return f.changed[key] }
+
+// TestInstallerInputHasChange verifies a change on either the inline or the
+// file attribute is reported, and that unrelated changes are ignored.
+func TestInstallerInputHasChange(t *testing.T) {
+	tests := []struct {
+		name    string
+		changed map[string]bool
+		spec    installerFileSpec
+		want    bool
+	}{
+		{
+			name:    "inline attr changed",
+			changed: map[string]bool{"application_settings": true},
+			spec:    applicationSettingsSpec,
+			want:    true,
+		},
+		{
+			name:    "file attr changed",
+			changed: map[string]bool{"application_settings_file": true},
+			spec:    applicationSettingsSpec,
+			want:    true,
+		},
+		{
+			name:    "unrelated change ignored",
+			changed: map[string]bool{"yba_version": true},
+			spec:    applicationSettingsSpec,
+			want:    false,
+		},
+		{
+			name:    "nothing changed",
+			changed: map[string]bool{},
+			spec:    applicationSettingsSpec,
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := fakeChangeDetector{changed: tt.changed}
+			if got := installerInputHasChange(d, tt.spec); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestInstallerSpecSets guards the static spec groupings: the license must
+// not leak into the reconfigure-only set (the bug the rebased commit fixed),
+// and the install set must be the union of both with a fresh backing array.
+func TestInstallerSpecSets(t *testing.T) {
+	for _, spec := range reconfigurationYBAInstallerSpecs() {
+		if spec.contentAttr == licenseSpec.contentAttr {
+			t.Fatalf("license spec leaked into the reconfigure-only set")
+		}
+	}
+
+	install := installationYBAInstallerSpecs()
+	want := len(reconfigurationYBAInstallerSpecs()) + len(licenseYBAInstallerSpecs())
+	if len(install) != want {
+		t.Fatalf("install set has %d specs, want %d", len(install), want)
+	}
+
+	// Mutating the returned slice must not affect a subsequent call.
+	install[0] = installerFileSpec{}
+	if installationYBAInstallerSpecs()[0] == (installerFileSpec{}) {
+		t.Fatalf("installationYBAInstallerSpecs returned a shared/mutable slice")
+	}
+}

--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os"
+	"strings"
 	"time"
 
 	"github.com/bramvdbogaerde/go-scp"
@@ -91,12 +91,15 @@ func waitForIP(ctx context.Context, user string, ip string, pk string, timeout t
 	return c.(*ssh.Client), nil
 }
 
-func scpFile(ctx context.Context,
+// scpContent copies the given in-memory content to the remote host
+// under the supplied path. It does not create any temporary file on
+// the local filesystem.
+func scpContent(ctx context.Context,
 	sshClient *ssh.Client,
-	localFile string,
+	content string,
 	remoteFile string) error {
-	tflog.Info(ctx, fmt.Sprintf("Copying local file %s to remote host under filename %s", localFile,
-		remoteFile))
+	tflog.Info(ctx, fmt.Sprintf("Copying inline content (%d bytes) to remote host under "+
+		"filename %s", len(content), remoteFile))
 
 	c, err := scp.NewClientBySSH(sshClient)
 	if err != nil {
@@ -110,9 +113,6 @@ func scpFile(ctx context.Context,
 	}
 	defer c.Close()
 
-	f, _ := os.Open(localFile)
-	defer func() { _ = f.Close() }()
-
-	err = c.CopyFromFile(context.Background(), *f, remoteFile, "0666")
-	return err
+	reader := strings.NewReader(content)
+	return c.Copy(context.Background(), reader, remoteFile, "0666", int64(len(content)))
 }

--- a/templates/resources/installer.md.tmpl
+++ b/templates/resources/installer.md.tmpl
@@ -14,19 +14,25 @@ description: |-
 
 {{ tffile "examples/resources/yba_installer/resource.tf" }}
 
+### Inline content vs. file paths
+
+Each input can be supplied either as an inline string or as a path to a local file. Inline (content-based) attributes are marked sensitive and are mutually exclusive with their file-based counterparts.
+
+| Inline content       | File path                   |
+| -------------------- | --------------------------- |
+| `ssh_private_key`    | `ssh_private_key_file_path` |
+| `application_settings` | `application_settings_file` |
+| `yba_license`        | `yba_license_file`          |
+| `tls_certificate`    | `tls_certificate_file`      |
+| `tls_key`            | `tls_key_file`              |
+
+Use the inline form when the value is already available inside Terraform (for example as the output of a `tls_private_key` resource or a Terraform variable). This avoids the need to materialise temporary files via `local_sensitive_file` just to satisfy the provider, and keeps sensitive material off the local filesystem.
+
 To upgrade YugabyteDB Anywhere version, change *yba_version* to the desired version and run *terraform apply*. In case the upgarde fails mid-way, taint the resource in the *terraform.tfstate* file and rerun the *apply* command.
 
--> **Note:** If modifications are made in the configuration file contents, set *reconfigure* to *true* for the changes to be acknowledged.
+-> **Note:** Changes to the inline `application_settings`, `tls_certificate`, or `tls_key` attributes (or their file-based equivalents) automatically trigger a reconfiguration on the next apply. The `reconfigure = true` flag is only needed when forcing reconfiguration without any tracked input change.
 
 -> **Note:** The paths for server certs and keys on the YugabyteDB Anywhere host are **/tmp/server.crt** and **/tmp/server.key** respectively, which need to be set in the configuration file before installation for proper usage.
-
-To change any of the following file contents -
-
-1. License File (yba_license_file)
-2. TLS Certificate File (tls_certificate_file)
-3. TLS Key File (tls_key_file)
-
-Change the path on the corresponding resource field and run *terraform apply* for the new files to be uploaded.
 
 For further details on configuration and host requirements, refer to [Install YBA software using YBA Installer](https://docs.yugabyte.com/stable/yugabyte-platform/install-yugabyte-platform/install-software/installer/).
 


### PR DESCRIPTION
## Summary

The `yba_installer` resource accepted five inputs only as file paths:

- `ssh_private_key_file_path`
- `application_settings_file`
- `yba_license_file`
- `tls_certificate_file`
- `tls_key_file`

That works when the files already exist, but is awkward when the values are generated inside Terraform: callers had to materialise `local_sensitive_file` resources just so the provider could read them back. Concretely:

- Extra boilerplate to pass values Terraform already has in memory.
- Plan-time file validation could fail because the provider's `os.Stat()` check ran before `local_sensitive_file` created the file.
- Sensitive data was written to the local filesystem.
- Change detection saw only path changes, not content changes, so callers often had to set `reconfigure = true` to force updates.

This PR adds content-based alternatives:

| Existing attribute (file path) | New attribute (inline content) |
| --- | --- |
| `ssh_private_key_file_path` | `ssh_private_key` |
| `application_settings_file` | `application_settings` |
| `yba_license_file` | `yba_license` |
| `tls_certificate_file` | `tls_certificate` |
| `tls_key_file` | `tls_key` |

The new attributes accept string content directly. Existing file-path attributes remain supported for backward compatibility — existing configurations keep working unchanged (no state migration, no recreation).

## Schema

- Each inline attribute is marked `Sensitive` and `ConflictsWith` its file-based counterpart.
- `ssh_private_key` + `ssh_private_key_file_path` and `yba_license` + `yba_license_file` additionally use `ExactlyOneOf`; callers must supply exactly one form.
- `tls_certificate` / `tls_certificate_file` must still be paired with `tls_key` / `tls_key_file`. The pairing is enforced in `CustomizeDiff` across both forms.
- `reconfigure` stays as an opt-in flag for forced reconfiguration when no tracked input has changed.
- The file-path attributes that used to be `Required` (`ssh_private_key_file_path`, `yba_license_file`) are now `Optional` + `ExactlyOneOf`, so existing configs that set them remain valid.

## Runtime

- Inputs are described by an `installerFileSpec` that lists the file attribute, the content attribute, and the remote target path. Helpers (`resolveInstallerInput`, `installerInputProvided`, `installerInputHasChange`) read whichever form the user supplied.
- When inline content is provided, `scpContent` streams it to the remote host via SCP from a `strings.Reader`; no local temp file is created.
- Plan-time file-existence checks now run only when the file-path attribute is non-empty, so the inline form no longer requires placeholder files on disk.
- `Update()` detects changes on either the inline or file form for license, application settings, TLS certificate, and TLS key, and triggers the corresponding `yba-ctl license-add` or `yba-ctl reconfigure` cycle automatically.

## Switching forms

The file and inline forms are interchangeable without recreating the resource (none of these attributes are `ForceNew`). Note that change detection compares each attribute string independently, so switching forms registers as a change and triggers the side effect for that input (`license-add` for the license, `reconfigure` for `application_settings`/`tls_*`) — even if the underlying content is identical. The SSH key switch is inert on the host (the key is only used to authenticate, never uploaded).

## Tests

A separate commit adds white-box unit tests for the new argument-resolution layer, which is pure and SSH-free. They drive the real resource schema via `schema.TestResourceDataRaw`:

- `resolveInstallerInput`: inline-over-file precedence (incl. both set), file fallback, neither-set, and missing-file error.
- `resolveSSHPrivateKey`: inline form, file form, and neither-set error.
- `installerInputProvided` / `installerInputHasChange` across both forms.
- `installerFileSpec` groupings: the license must not leak into the reconfigure-only set, and the install set returns a fresh slice.
- Schema `InternalValidate`, guarding the `ConflictsWith` / `ExactlyOneOf` attribute-name wiring.

The SSH/`yba-ctl` command paths (`scpContent`, `uploadInstallerInputs`, install/reconfigure/upgrade) require a live host and are out of scope for unit tests; they are exercised by the acceptance fixture.

## Drive-by

- `getInstallationFiles` previously aliased `reconfigurationYBAInstallerFiles` and mutated it via `maps.Copy` on every call, leaking the license entry into the reconfigure-only set. The replacement uses immutable `installerFileSpec` slices and returns a fresh allocation per call.
- Removed the now-unused `scpFile` helper (every caller migrated to `scpContent`).

## Reference

Workaround being retired in `yugabyte/byoc-setup`: https://github.com/yugabyte/byoc-setup/blob/main/modules/yba-install/main.tf

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` clean (Lint CI green)
- [x] `go test ./...` all green, incl. new `internal/installation` unit tests (Unit Tests CI green)
- [x] `make documents` regenerates with no drift
- [x] Manual verification against a real YBA host using the inline-content form
