### PR TITLE
[PLAT-20678] Fix unauthenticated bootstrap mode

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -147,6 +147,14 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 		return nil, diag.FromErr(err)
 	}
 
+	// Unauthenticated bootstrap mode: when no api_token is set, the
+	// provider is being used to install YBA via yba_installer on a host
+	// where YBA is not yet running. Skip the version check — resources
+	// that require it (cloud providers, etc.) need an api_token anyway.
+	if apiKey == "" {
+		return c, diags
+	}
+
 	// Enforce minimum YBA version requirement
 	// The Terraform provider requires YBA >= 2024.2.0.0-b1
 	if err := utils.CheckMinimumYBAVersion(ctx, c.YugawareClient); err != nil {


### PR DESCRIPTION
providerConfigure unconditionally probes /api/v1/app_version on the configured host via CheckMinimumYBAVersion. Provider configure runs before any resource Create during plan, so this call happens even when the only resource present is yba_installer (whose entire purpose is to install YBA on a host where it is not yet running). The result is that `terraform plan` fails with "connection refused" on every fresh deploy that uses the documented unauthenticated bootstrap flow:

    Error: Validation: YBA Version, Operation: Get App Version - Get
    "https://10.0.0.1:9443/api/v1/app_version": dial tcp 10.0.0.1:9443:
    connect: connection refused

      with provider["registry.terraform.io/yugabyte/yba"].install,
      on providers.tf line 1, in provider "yba":
       1: provider "yba" {

The unconditional check was introduced in 995e97c (PLAT-9360 / PLAT-17988, "Revamp provider resources and update the go-client"). Earlier versions of providerConfigure only constructed the API client without probing it. The provider documentation
(docs/index.md, docs/resources/installer.md,
docs/resources/customer_resource.md,
docs/guides/running-terraform-on-existing-yba-installations.md, examples/provider/provider.tf) still documents the unauthenticated bootstrap mode:

    provider "yba" {
      alias = "unauthenticated"
      host  = "<host-ip-address>"
    }

so this is a regression, not a documentation bug.

Skip CheckMinimumYBAVersion when api_token is empty. Resources that genuinely require a working YBA API (cloud providers, universes, backups, storage configs, ...) all need an api_token to function, so the version check is preserved for any meaningful use of the API. yba_installer and yba_customer_resource are the only resources usable without an api_token, and both bootstrap a fresh YBA install where the version check is meaningless.

Acceptance:

- terraform plan succeeds for a yba_installer resource when YBA is not yet reachable on the configured host (unauthenticated provider, no api_token).
- terraform plan/apply against a configured (authenticated) provider with api_token continues to fail fast on hosts running YBA versions older than YBATerraformProviderMinStableVersion / YBATerraformProviderMinPreviewVersion.
