### PR TITLE
Use TypeSet for unordered audit-log and metrics fields

### DIFF
--- a/docs/resources/universe_telemetry_config.md
+++ b/docs/resources/universe_telemetry_config.md
@@ -4,6 +4,7 @@ description: |-
   Universe Telemetry Config Resource. Attaches audit log, query log, and metrics export pipelines to a YBA universe via the unified export-telemetry-configs API. Each exporter references a yba_telemetry_provider (or any pre-existing telemetry provider UUID) and triggers a rolling/non-rolling restart of the universe to install or update the OpenTelemetry collector.
   ~> Note: OTLP-based exporters require the global runtime config yb.telemetry.allow_otlp to be set to true. Manage that with the yba_runtime_config resource.
   ~> Note: This resource does not currently support importing an existing universe-level configuration; recreate the resource by applying the desired state.
+  ~> Dependency Note: When exporter_uuid is wired through a reference like yba_telemetry_provider.x.id, Terraform's dependency graph automatically orders create / replace / destroy of the provider before this resource — there is no need to add an explicit depends_on. The provider's own destroy step also proactively detaches itself from every referencing universe before deletion, so a plan that destroys-and-recreates a provider in the same apply is safe.
 ---
 
 # yba_universe_telemetry_config (Resource)
@@ -121,7 +122,7 @@ resource "yba_universe_telemetry_config" "main" {
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `upgrade_options` (Block List, Max: 1) Optional rolling-restart options applied while reconfiguring the universe.
 
-  ~> **Performance Note:** The `sleep_after_*_restart_millis` defaults of 180000 (3 minutes) are applied per node. A 9-node universe therefore spends ~27 minutes just sleeping between restarts on top of the actual restart work. Lower these values for faster reconfigures on healthy clusters, or raise them for clusters under heavy traffic. (see [below for nested schema](#nestedblock--upgrade_options))
+~> **Performance Note:** The `sleep_after_*_restart_millis` defaults of 180000 (3 minutes) are applied per node. A 9-node universe therefore spends ~27 minutes just sleeping between restarts on top of the actual restart work. Lower these values for faster reconfigures on healthy clusters, or raise them for clusters under heavy traffic. (see [below for nested schema](#nestedblock--upgrade_options))
 
 ### Read-Only
 
@@ -154,12 +155,12 @@ Optional:
 Optional:
 
 - `enabled` (Boolean)
-- `excluded_categories` (List of String)
-- `excluded_keyspaces` (List of String)
-- `excluded_users` (List of String)
-- `included_categories` (List of String)
-- `included_keyspaces` (List of String)
-- `included_users` (List of String)
+- `excluded_categories` (Set of String)
+- `excluded_keyspaces` (Set of String)
+- `excluded_users` (Set of String)
+- `included_categories` (Set of String)
+- `included_keyspaces` (Set of String)
+- `included_users` (Set of String)
 - `log_level` (String)
 
 
@@ -168,7 +169,7 @@ Optional:
 
 Optional:
 
-- `classes` (List of String) YSQL audit log classes (e.g. READ, WRITE, DDL, ROLE).
+- `classes` (Set of String) YSQL audit log classes (e.g. READ, WRITE, DDL, ROLE).
 - `enabled` (Boolean)
 - `log_catalog` (Boolean)
 - `log_client` (Boolean)
@@ -189,7 +190,7 @@ Optional:
 
 - `collection_level` (String)
 - `exporter` (Block List) (see [below for nested schema](#nestedblock--metrics--exporter))
-- `scrape_config_targets` (List of String)
+- `scrape_config_targets` (Set of String)
 - `scrape_interval_seconds` (Number)
 - `scrape_timeout_seconds` (Number)
 

--- a/internal/telemetry/resource_universe_telemetry_config.go
+++ b/internal/telemetry/resource_universe_telemetry_config.go
@@ -165,7 +165,7 @@ func auditLogsSchema() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"enabled": {Type: schema.TypeBool, Optional: true, Default: false},
 							"classes": {
-								Type:        schema.TypeList,
+								Type:        schema.TypeSet,
 								Optional:    true,
 								Elem:        &schema.Schema{Type: schema.TypeString},
 								Description: "YSQL audit log classes (e.g. READ, WRITE, DDL, ROLE).",
@@ -190,12 +190,12 @@ func auditLogsSchema() *schema.Schema {
 						Schema: map[string]*schema.Schema{
 							"enabled":             {Type: schema.TypeBool, Optional: true, Default: false},
 							"log_level":           {Type: schema.TypeString, Optional: true, Default: "WARNING"},
-							"included_categories": {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"excluded_categories": {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"included_keyspaces":  {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"excluded_keyspaces":  {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"included_users":      {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
-							"excluded_users":      {Type: schema.TypeList, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"included_categories": {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"excluded_categories": {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"included_keyspaces":  {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"excluded_keyspaces":  {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"included_users":      {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
+							"excluded_users":      {Type: schema.TypeSet, Optional: true, Elem: &schema.Schema{Type: schema.TypeString}},
 						},
 					},
 				},
@@ -273,7 +273,7 @@ func metricsSchema() *schema.Schema {
 					ValidateFunc: validation.StringInSlice(allowedCollectionLevels, false),
 				},
 				"scrape_config_targets": {
-					Type:     schema.TypeList,
+					Type:     schema.TypeSet,
 					Optional: true,
 					Elem: &schema.Schema{
 						Type:         schema.TypeString,
@@ -723,16 +723,20 @@ func intValue(in interface{}) int {
 	return 0
 }
 
-// stringList converts a Terraform list of strings (always []interface{}) to a
-// concrete []string.
+// stringList converts a Terraform collection of strings to a concrete
+// []string. TypeList fields decode to []interface{}; TypeSet fields decode
+// to *schema.Set, so callers can hand either shape to this helper.
 func stringList(in interface{}) []string {
 	out := []string{}
-	list, ok := in.([]interface{})
-	if !ok {
-		return out
-	}
-	for _, item := range list {
-		out = append(out, stringValue(item))
+	switch v := in.(type) {
+	case []interface{}:
+		for _, item := range v {
+			out = append(out, stringValue(item))
+		}
+	case *schema.Set:
+		for _, item := range v.List() {
+			out = append(out, stringValue(item))
+		}
 	}
 	return out
 }


### PR DESCRIPTION
## Summary

Eight string-collection fields on `yba_universe_telemetry_config` were
declared as `TypeList`, but YBA persists them as Java `Set<...>`:

- `YSQLAuditConfig.classes` — `Set<YSQLAuditStatementClass>`
- `YCQLAuditConfig.{included,excluded}{Categories,Keyspaces,Users}` —
  `Set<YCQLAuditCategory>` / `Set<String>`
- `MetricsExportConfig.scrapeConfigTargets` — `Set<ScrapeConfigTargetType>`
  (initialised to `EnumSet.allOf(...)`)

Because the server cannot preserve array order on a `Set`, Jackson
serialises these collections back in non-deterministic order, and every
`terraform plan` after refresh shows a phantom diff against the
order-sensitive `TypeList` shape in state.

### What changed

- `internal/telemetry/resource_universe_telemetry_config.go`: flip the
  eight schema fields above to `TypeSet`. Block structure, `Optional`,
  `Elem`, and the existing `ValidateFunc` on `scrape_config_targets`
  are unchanged.
- `internal/telemetry/resource_universe_telemetry_config.go`: extend the
  `stringList` helper to branch on `*schema.Set` in addition to
  `[]interface{}` — `d.Get(...)` and nested-map lookups return
  `*schema.Set` for `TypeSet` fields. This single helper feeds every
  affected build path (`buildYsqlAuditConfig`, `buildYcqlAuditConfig`,
  `buildMetrics`).
- `docs/resources/universe_telemetry_config.md`: regenerated via
  `make documents`. The eight fields now render as `(Set of String)`.

### Out of scope (intentional)

- All other `TypeList` fields on this resource — `exporter` lists,
  `upgrade_options`, and the `*_audit_config` / `*_query_log_config`
  blocks — stay as-is. They are order-bearing structures in the YBA
  payload.
- `byoc-setup/modules/yba-telemetry/main.tf`: the
  `lifecycle.ignore_changes = [metrics[0].scrape_config_targets]`
  workaround is intentionally left in place. It is still useful while
  customers run a provider version older than this change.

### Notes on the docs diff

`make documents` also picks up two pre-existing drifts in the same
file that are unrelated to the type flip: a `Dependency Note`
paragraph that lives in the resource `Description` (added in an
earlier change), and a leading-whitespace tweak the renderer now
applies to the `Performance Note`. Both come from the canonical
schema source — stripping them would only invite the next
regeneration to bring them back.

## Test plan

- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./internal/telemetry/...` (existing build-spec tests
      assert `len(...)` of the marshaled JSON, not ordering)
- [x] `make documents` — diff confirms only the eight affected fields
      flipped to `(Set of String)`
- [ ] Manual: re-apply against a live YBA universe, confirm no phantom
      diff on subsequent `terraform plan`

Made with [Cursor](https://cursor.com)