### PR TITLE
Adding support for install with data disk

### DIFF
--- a/docs/resources/installer.md
+++ b/docs/resources/installer.md
@@ -2,6 +2,7 @@
 page_title: "yba_installer Resource - YugabyteDB Anywhere"
 description: |-
   Manages the installation of YugabyteDB Anywhere on an existing virtual machine using YBA Installer.
+  ~> Note: When /opt/yugabyte/data is already populated (typically because it lives on a separately managed persistent disk that survives the host VM), the resource installs with --without-data and starts services in place rather than reinitialising storage. Destroy runs yba-ctl clean only and leaves /opt/yugabyte/data intact; wiping the data directory is the operator's responsibility.
 ---
 
 # yba_installer (Resource)
@@ -9,6 +10,8 @@ description: |-
 -> **Note:** Ensure the YugabyteDB Anywhere host has **curl** installed to allow the YBA Installer package downloads during *terraform apply*.
 
 Manages the installation of YugabyteDB Anywhere on an existing virtual machine using YBA Installer.
+
+~> **Note:** When `/opt/yugabyte/data` is already populated (typically because it lives on a separately managed persistent disk that survives the host VM), the resource installs with `--without-data` and starts services in place rather than reinitialising storage. Destroy runs `yba-ctl clean` only and leaves `/opt/yugabyte/data` intact; wiping the data directory is the operator's responsibility.
 
 ### Supported Versions
 

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -192,7 +192,14 @@ func installerInputProvided(d inputReader, spec installerFileSpec) bool {
 func ResourceYBAInstaller() *schema.Resource {
 	return &schema.Resource{
 		Description: "Manages the installation of YugabyteDB Anywhere on an existing virtual" +
-			" machine using YBA Installer. ",
+			" machine using YBA Installer.\n\n" +
+			"~> **Note:** When `/opt/yugabyte/data` is already populated " +
+			"(typically because it lives on a separately managed " +
+			"persistent disk that survives the host VM), the resource " +
+			"installs with `--without-data` and starts services in place " +
+			"rather than reinitialising storage. Destroy runs `yba-ctl " +
+			"clean` only and leaves `/opt/yugabyte/data` intact; wiping " +
+			"the data directory is the operator's responsibility.",
 
 		CreateContext: resourceYBAInstallerCreate,
 		ReadContext:   resourceYBAInstallerRead,
@@ -624,7 +631,19 @@ func resourceYBAInstallerDelete(
 
 	sshClient, err := newSSHClient(user, hostIPForSSH, pk)
 	if err != nil {
-		return diag.FromErr(err)
+		// The host may already be gone (e.g. caller wired
+		// lifecycle.replace_triggered_by to the cloud VM, so the VM
+		// was destroyed first; or the host is simply unreachable
+		// during the destroy half of a replace cycle). In every such
+		// case there's nothing to clean up remotely, and an empty
+		// host is the desired terminal state. Surface the reason and
+		// move on rather than blocking destroy on a side effect that
+		// can never succeed.
+		tflog.Warn(ctx, fmt.Sprintf(
+			"yba_installer: skipping remote cleanup, SSH to %s failed: %v",
+			hostIPForSSH, err))
+		d.SetId("")
+		return diags
 	}
 	defer sshClient.Close()
 
@@ -685,27 +704,53 @@ func getAddLicenseCommand(version, folder string) string {
 	return fmt.Sprintf("sudo YBA_MODE=dev ./%s/yba-ctl license add -l /tmp/license.lic", folder)
 }
 
+// getInstallCommands returns the ordered list of shell commands that
+// stage and run a fresh YBA install. The final command auto-detects
+// whether /opt/yugabyte/data is already populated (e.g. a separately
+// managed persistent data disk that survived an OS-image upgrade) and
+// picks the correct yba-ctl invocation. When the data dir is
+// non-empty the install runs with --without-data and is followed by
+// `yba-ctl start`; otherwise the original `install -f` path runs
+// untouched, which keeps callers that don't use a separate data disk
+// behaving exactly as before.
 func getInstallCommands(
 	version, os, arch string,
 	config bool, skipPreflightCheckList *[]string) []string {
-	var s string
-	folder, installationCommands := getYBAInstallerBundle(version, os, arch)
-	s = getAddLicenseCommand(version, folder)
-	installationCommands = append(installationCommands, s)
+	folder, cmds := getYBAInstallerBundle(version, os, arch)
+	cmds = append(cmds, getAddLicenseCommand(version, folder))
 	if config {
-		installationCommands = append(installationCommands,
+		// The yba_installer_full tarball doesn't create /opt/yba-ctl
+		// before `install` runs; mkdir -p keeps the staged mv safe on
+		// hosts where the directory doesn't yet exist.
+		cmds = append(cmds,
+			"sudo mkdir -p /opt/yba-ctl",
 			"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml")
 	}
+
+	var installPrefix, ybactl string
 	if IsGAVersion(version) {
-		s = fmt.Sprintf("sudo ./%s/yba-ctl install -f", folder)
+		installPrefix = fmt.Sprintf("sudo ./%s/yba-ctl install -f", folder)
+		ybactl = "sudo /opt/yba-ctl/yba-ctl"
 	} else {
-		s = fmt.Sprintf("sudo YBA_MODE=dev ./%s/yba-ctl install -f", folder)
+		installPrefix = fmt.Sprintf("sudo YBA_MODE=dev ./%s/yba-ctl install -f", folder)
+		ybactl = "sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl"
 	}
+
+	skipSuffix := ""
 	if skipPreflightCheckList != nil && len(*skipPreflightCheckList) != 0 {
-		s = fmt.Sprintf("%s -s %s", s, strings.Join(*skipPreflightCheckList, ","))
+		skipSuffix = fmt.Sprintf(" -s %s", strings.Join(*skipPreflightCheckList, ","))
 	}
-	installationCommands = append(installationCommands, s)
-	return installationCommands
+
+	cmds = append(cmds, fmt.Sprintf(
+		`if [ -d /opt/yugabyte/data ] && `+
+			`[ -n "$(sudo ls -A /opt/yugabyte/data 2>/dev/null)" ]; then `+
+			`%s --without-data%s && %s start; `+
+			`else %s%s; `+
+			`fi`,
+		installPrefix, skipSuffix, ybactl,
+		installPrefix, skipSuffix,
+	))
+	return cmds
 }
 
 func getReconfigureCommands(version string) []string {
@@ -739,16 +784,21 @@ func getUpgradeCommands(version, os, arch string, skipPreflightCheckList *[]stri
 	return updateCommands
 }
 
+// getDeleteCommands returns the shell commands run during resource
+// destroy. yba-ctl clean (without --all) stops services and removes
+// /opt/yba-ctl/ but deliberately preserves /opt/yugabyte/data; that
+// matters when the data directory lives on a separately managed
+// persistent disk that must outlive the YBA host. Explicit data wipe
+// is the operator's responsibility, not this resource's.
 func getDeleteCommands(version string) []string {
-	var s string
+	var clean string
 	if IsGAVersion(version) {
-		s = "sudo /opt/yba-ctl/yba-ctl clean"
+		clean = "sudo /opt/yba-ctl/yba-ctl clean"
 	} else {
-		s = "sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl clean"
+		clean = "sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl clean"
 	}
-	var deleteCommands = []string{s}
-	deleteCommands = append(deleteCommands, "sudo rm -rf /opt/yugabyte")
-	deleteCommands = append(deleteCommands,
-		"sudo rm /tmp/server.crt /tmp/server.key /tmp/license.lic /tmp/settings.yml")
-	return deleteCommands
+	return []string{
+		clean,
+		"sudo rm -f /tmp/server.crt /tmp/server.key /tmp/license.lic /tmp/settings.yml",
+	}
 }

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -242,15 +242,91 @@ func TestGetYBAInstallerBundle(t *testing.T) {
 
 func TestGetInstallCommandsWithConfig(t *testing.T) {
 	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", true, nil)
-	// Expected order: curl, tar, license add, mv settings.yml, install
-	if len(cmds) != 5 {
-		t.Fatalf("expected 5 commands when config=true, got %d: %v", len(cmds), cmds)
+	// Expected order: curl, tar, license add, mkdir /opt/yba-ctl,
+	// mv settings.yml, combined install (bash if-else).
+	if len(cmds) != 6 {
+		t.Fatalf("expected 6 commands when config=true, got %d: %v", len(cmds), cmds)
 	}
-	if !strings.Contains(cmds[3], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
-		t.Errorf("expected settings move at index 3, got %q", cmds[3])
+	if !strings.Contains(cmds[3], "mkdir -p /opt/yba-ctl") {
+		t.Errorf("expected /opt/yba-ctl mkdir at index 3, got %q", cmds[3])
 	}
-	if !strings.Contains(cmds[4], "yba-ctl install -f") {
-		t.Errorf("expected install command at index 4, got %q", cmds[4])
+	if !strings.Contains(cmds[4], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
+		t.Errorf("expected settings move at index 4, got %q", cmds[4])
+	}
+	last := cmds[len(cmds)-1]
+	if !strings.Contains(last, "yba-ctl install -f") {
+		t.Errorf("expected combined install command, got %q", last)
+	}
+	if !strings.Contains(last, "--without-data") {
+		t.Errorf("expected combined install to include --without-data branch, got %q", last)
+	}
+}
+
+// TestGetInstallCommandsWithoutConfig verifies that when no
+// application_settings input is supplied, the function does not stage
+// /opt/yba-ctl/yba-ctl.yml. The combined install must still be the last
+// command so callers that grep cmds[len-1] for the install flags keep
+// working.
+func TestGetInstallCommandsWithoutConfig(t *testing.T) {
+	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", false, nil)
+	if len(cmds) != 4 {
+		t.Fatalf("expected 4 commands when config=false, got %d: %v", len(cmds), cmds)
+	}
+	for i, cmd := range cmds {
+		if strings.Contains(cmd, "mkdir -p /opt/yba-ctl") {
+			t.Errorf("did not expect /opt/yba-ctl mkdir when config=false, found at %d: %q",
+				i, cmd)
+		}
+		if strings.Contains(cmd, "mv /tmp/settings.yml") {
+			t.Errorf("did not expect settings move when config=false, found at %d: %q",
+				i, cmd)
+		}
+	}
+	last := cmds[len(cmds)-1]
+	if !strings.Contains(last, "yba-ctl install -f") {
+		t.Errorf("expected install -f in last command, got %q", last)
+	}
+}
+
+// TestGetInstallCommandsDataDirBranch locks in the bash structure that
+// picks between fresh install and --without-data install. A regression
+// here would silently re-initialise storage on a host that booted with
+// a pre-populated /opt/yugabyte/data disk attached.
+func TestGetInstallCommandsDataDirBranch(t *testing.T) {
+	skip := []string{"diskAvailability"}
+	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", true, &skip)
+	last := cmds[len(cmds)-1]
+
+	wantSubstrings := []string{
+		`if [ -d /opt/yugabyte/data ]`,
+		`[ -n "$(sudo ls -A /opt/yugabyte/data 2>/dev/null)" ]`,
+		`yba-ctl install -f --without-data -s diskAvailability`,
+		`/opt/yba-ctl/yba-ctl start`,
+		`else sudo ./yba_installer_full-2024.1.0.0-b129/yba-ctl install -f -s diskAvailability;`,
+		`fi`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(last, want) {
+			t.Errorf("combined install missing %q, got %q", want, last)
+		}
+	}
+}
+
+// TestGetInstallCommandsDataDirBranchPreRelease confirms YBA_MODE=dev
+// propagates into both branches and the yba-ctl start fallback.
+func TestGetInstallCommandsDataDirBranchPreRelease(t *testing.T) {
+	cmds := getInstallCommands("2.25.0.0-b300", "linux", "x86_64", false, nil)
+	last := cmds[len(cmds)-1]
+
+	wantSubstrings := []string{
+		`sudo YBA_MODE=dev ./yba_installer_full-2.25.0.0-b300/yba-ctl install -f --without-data`,
+		`sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl start`,
+		`else sudo YBA_MODE=dev ./yba_installer_full-2.25.0.0-b300/yba-ctl install -f;`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(last, want) {
+			t.Errorf("combined install missing %q, got %q", want, last)
+		}
 	}
 }
 
@@ -492,26 +568,37 @@ func TestGetDeleteCommands(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmds := getDeleteCommands(tt.version)
-			if len(cmds) != 3 {
-				t.Fatalf("expected 3 commands (clean, rm yugabyte, rm tmp), got %d: %v",
+			if len(cmds) != 2 {
+				t.Fatalf("expected 2 commands (clean, rm tmp), got %d: %v",
 					len(cmds), cmds)
 			}
 			if !strings.Contains(cmds[0], "/opt/yba-ctl/yba-ctl clean") {
 				t.Errorf("expected clean command first, got %q", cmds[0])
+			}
+			// `--all` would wipe /opt/yugabyte/data which must outlive
+			// the resource when a separate data disk is mounted there.
+			if strings.Contains(cmds[0], "--all") {
+				t.Errorf("clean must not pass --all, got %q", cmds[0])
 			}
 			hasEnv := strings.Contains(cmds[0], "YBA_MODE=dev")
 			if hasEnv != tt.expectedEnv {
 				t.Errorf("YBA_MODE=dev presence = %v, expected %v in %q",
 					hasEnv, tt.expectedEnv, cmds[0])
 			}
-			if cmds[1] != "sudo rm -rf /opt/yugabyte" {
-				t.Errorf("expected rm -rf /opt/yugabyte, got %q", cmds[1])
+			if !strings.Contains(cmds[1], "/tmp/server.crt") ||
+				!strings.Contains(cmds[1], "/tmp/server.key") ||
+				!strings.Contains(cmds[1], "/tmp/license.lic") ||
+				!strings.Contains(cmds[1], "/tmp/settings.yml") {
+				t.Errorf("expected rm of all tmp files, got %q", cmds[1])
 			}
-			if !strings.Contains(cmds[2], "/tmp/server.crt") ||
-				!strings.Contains(cmds[2], "/tmp/server.key") ||
-				!strings.Contains(cmds[2], "/tmp/license.lic") ||
-				!strings.Contains(cmds[2], "/tmp/settings.yml") {
-				t.Errorf("expected rm of all tmp files, got %q", cmds[2])
+			// Regression: an earlier version of this function ran
+			// `sudo rm -rf /opt/yugabyte`, which would wipe the data
+			// disk on every destroy/replace cycle.
+			for i, cmd := range cmds {
+				if strings.Contains(cmd, "rm -rf /opt/yugabyte") {
+					t.Errorf("delete commands must not wipe /opt/yugabyte, found at %d: %q",
+						i, cmd)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
### Description
Adds support for recreation of YBA but install will now detect if data disk is populated already and then run install --without-data followed by a start. 


### References
Used with https://github.com/yugabyte/byoc-setup/pull/53 to test YBA OS image upgrade


### Output from Acceptance Testing


```
$ make testacc

...
```
