### PR TITLE
[Terraform] Add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,24 @@
+# EditorConfig: https://editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+max_line_length = 100
+
+[*.go]
+indent_style = tab
+indent_size = 4
+
+[{Makefile,GNUmakefile}]
+indent_style = tab
+
+[{*.json,.arclint}]
+indent_size = 4
+
+[*.md]
+max_line_length = off


### PR DESCRIPTION
Capture repo conventions: LF, UTF-8, final newline, trim trailing whitespace, tab for Go and Makefiles, 4-space JSON, no line-length cap on Markdown.
