### PR TITLE
Adding terraform provider support to update load balancer

### DIFF
--- a/internal/api/load_balancer.go
+++ b/internal/api/load_balancer.go
@@ -1,0 +1,49 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/yugabyte/terraform-provider-yba/internal/utils"
+)
+
+// UpdateLBConfig calls PUT /universes/{uuid}/update_lb_config with the
+// modified universeDetails payload. Returns the async task UUID.
+func (vc *VanillaClient) UpdateLBConfig(
+	cUUID, uUUID string,
+	universeDetails interface{},
+	token string,
+) (string, error) {
+	reqBytes, err := json.Marshal(universeDetails)
+	if err != nil {
+		return "", fmt.Errorf("marshal update_lb_config request: %w", err)
+	}
+
+	path := fmt.Sprintf("api/v1/customers/%s/universes/%s/update_lb_config", cUUID, uUUID)
+	res, err := vc.makeRequest(http.MethodPut, path, bytes.NewBuffer(reqBytes), token)
+	if err != nil {
+		return "", fmt.Errorf("update_lb_config request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if httpErr := utils.CheckHTTPError(res, "UpdateLBConfig"); httpErr != nil {
+		return "", httpErr
+	}
+
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading update_lb_config response: %w", err)
+	}
+
+	var resp struct {
+		TaskUUID string `json:"taskUUID"`
+	}
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return "", fmt.Errorf("error parsing update_lb_config response: %w", err)
+	}
+
+	return resp.TaskUUID, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -135,6 +135,9 @@ func New() *schema.Provider {
 			"yba_telemetry_provider":        telemetry.ResourceTelemetryProvider(),
 			"yba_universe_telemetry_config": telemetry.ResourceUniverseTelemetryConfig(),
 			"yba_runtime_config":            telemetry.ResourceRuntimeConfig(),
+
+			// Universe load balancer association (update_lb_config API).
+			"yba_universe_load_balancer": universe.ResourceUniverseLoadBalancer(),
 		},
 		ConfigureContextFunc: providerConfigure,
 	}

--- a/internal/universe/resource_universe_load_balancer.go
+++ b/internal/universe/resource_universe_load_balancer.go
@@ -1,0 +1,277 @@
+package universe
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	client "github.com/yugabyte/platform-go-client"
+	"github.com/yugabyte/terraform-provider-yba/internal/api"
+	"github.com/yugabyte/terraform-provider-yba/internal/utils"
+)
+
+// ResourceUniverseLoadBalancer manages load balancer associations on a
+// YBA universe via the update_lb_config API endpoint.
+func ResourceUniverseLoadBalancer() *schema.Resource {
+	return &schema.Resource{
+		Description: "Manages load balancer associations on a YugabyteDB Anywhere " +
+			"universe. Maps GCP region codes to forwarding rule names so that " +
+			"YBA can attach universe nodes to the corresponding backend services.\n\n" +
+			"This resource calls the `update_lb_config` API, which is separate " +
+			"from the universe create/update lifecycle. The universe must exist " +
+			"before this resource is created.",
+
+		CreateContext: resourceUniverseLBCreate,
+		ReadContext:   resourceUniverseLBRead,
+		UpdateContext: resourceUniverseLBUpdate,
+		DeleteContext: resourceUniverseLBDelete,
+
+		Timeouts: &schema.ResourceTimeout{
+			Create: schema.DefaultTimeout(10 * time.Minute),
+			Update: schema.DefaultTimeout(10 * time.Minute),
+			Delete: schema.DefaultTimeout(10 * time.Minute),
+		},
+
+		Schema: map[string]*schema.Schema{
+			"universe_uuid": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "UUID of the universe to attach load balancers to.",
+			},
+			"load_balancers": {
+				Type:        schema.TypeMap,
+				Required:    true,
+				Description: "Map of region code to load balancer forwarding rule name.",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+		},
+	}
+}
+
+func resourceUniverseLBCreate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	c := meta.(*api.APIClient)
+	uUUID := d.Get("universe_uuid").(string)
+	lbMap := expandLBMap(d.Get("load_balancers").(map[string]interface{}))
+
+	taskUUID, err := applyLBConfig(ctx, c, uUUID, lbMap, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	d.SetId(uUUID)
+
+	tflog.Debug(ctx, fmt.Sprintf("Waiting for update_lb_config task %s", taskUUID))
+	if err := utils.WaitForTask(ctx, taskUUID, c.CustomerID, c.YugawareClient,
+		d.Timeout(schema.TimeoutCreate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceUniverseLBRead(ctx, d, meta)
+}
+
+func resourceUniverseLBRead(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	c := meta.(*api.APIClient)
+	uUUID := d.Id()
+
+	uni, response, err := c.YugawareClient.UniverseManagementAPI.
+		GetUniverse(ctx, c.CustomerID, uUUID).Execute()
+	if err != nil {
+		if utils.IsHTTPNotFound(response) || utils.IsHTTPBadRequestNotFound(response) {
+			tflog.Warn(ctx, fmt.Sprintf(
+				"Universe %s not found, removing LB config from state", uUUID))
+			d.SetId("")
+			return nil
+		}
+		return diag.FromErr(utils.ErrorFromHTTPResponse(response, err,
+			utils.ResourceEntity, "Universe Load Balancer", "Read"))
+	}
+
+	lbMap := extractLBMapFromUniverse(uni)
+
+	if err := d.Set("universe_uuid", uUUID); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("load_balancers", lbMap); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func resourceUniverseLBUpdate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	c := meta.(*api.APIClient)
+	uUUID := d.Id()
+	lbMap := expandLBMap(d.Get("load_balancers").(map[string]interface{}))
+
+	taskUUID, err := applyLBConfig(ctx, c, uUUID, lbMap, true)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Waiting for update_lb_config task %s", taskUUID))
+	if err := utils.WaitForTask(ctx, taskUUID, c.CustomerID, c.YugawareClient,
+		d.Timeout(schema.TimeoutUpdate)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return resourceUniverseLBRead(ctx, d, meta)
+}
+
+func resourceUniverseLBDelete(
+	ctx context.Context,
+	d *schema.ResourceData,
+	meta interface{},
+) diag.Diagnostics {
+	c := meta.(*api.APIClient)
+	uUUID := d.Id()
+
+	taskUUID, err := applyLBConfig(ctx, c, uUUID, nil, false)
+	if err != nil {
+		return diag.FromErr(err)
+	}
+
+	tflog.Debug(ctx, fmt.Sprintf("Waiting for update_lb_config task %s (remove LB)", taskUUID))
+	if err := utils.WaitForTask(ctx, taskUUID, c.CustomerID, c.YugawareClient,
+		d.Timeout(schema.TimeoutDelete)); err != nil {
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+// applyLBConfig fetches the universe, modifies LB settings on the
+// primary cluster, and calls the update_lb_config API.
+func applyLBConfig(
+	ctx context.Context,
+	c *api.APIClient,
+	uUUID string,
+	lbMap map[string]string,
+	enableLB bool,
+) (string, error) {
+	uni, response, err := c.YugawareClient.UniverseManagementAPI.
+		GetUniverse(ctx, c.CustomerID, uUUID).Execute()
+	if err != nil {
+		return "", utils.ErrorFromHTTPResponse(response, err,
+			utils.ResourceEntity, "Universe Load Balancer", "Get Universe")
+	}
+
+	details := uni.UniverseDetails
+	cluster := findPrimaryCluster(details.Clusters)
+	if cluster == nil {
+		return "", fmt.Errorf("universe %s: no PRIMARY cluster found", uUUID)
+	}
+
+	cluster.UserIntent.EnableLB = &enableLB
+	setLBNamesOnPlacement(cluster, lbMap, enableLB)
+
+	tflog.Info(ctx, fmt.Sprintf(
+		"Calling update_lb_config on universe %s (enableLB=%t)", uUUID, enableLB))
+
+	taskUUID, err := c.VanillaClient.UpdateLBConfig(
+		c.CustomerID, uUUID, details, c.APIKey)
+	if err != nil {
+		return "", fmt.Errorf("update_lb_config on universe %s: %w", uUUID, err)
+	}
+
+	return taskUUID, nil
+}
+
+func findPrimaryCluster(clusters []client.Cluster) *client.Cluster {
+	for i := range clusters {
+		if clusters[i].GetClusterType() == "PRIMARY" {
+			return &clusters[i]
+		}
+	}
+	return nil
+}
+
+// setLBNamesOnPlacement walks placementInfo.cloudList to set or clear
+// lbName on each AZ whose region matches the provided map.
+func setLBNamesOnPlacement(
+	cluster *client.Cluster,
+	lbMap map[string]string,
+	enableLB bool,
+) {
+	pi := cluster.PlacementInfo
+	if pi == nil {
+		return
+	}
+	for ci := range pi.CloudList {
+		cloud := &pi.CloudList[ci]
+		for ri := range cloud.RegionList {
+			region := &cloud.RegionList[ri]
+			regionCode := region.GetCode()
+			for ai := range region.AzList {
+				az := &region.AzList[ai]
+				if !enableLB {
+					az.LbName = nil
+					continue
+				}
+				if lbName, found := lbMap[regionCode]; found {
+					az.LbName = &lbName
+				}
+			}
+		}
+	}
+}
+
+// extractLBMapFromUniverse reads the current lbName from each AZ in the
+// primary cluster and returns a deduplicated region -> lbName map.
+func extractLBMapFromUniverse(uni *client.UniverseResp) map[string]string {
+	result := make(map[string]string)
+	details := uni.UniverseDetails
+	if details == nil {
+		return result
+	}
+
+	cluster := findPrimaryCluster(details.Clusters)
+	if cluster == nil {
+		return result
+	}
+
+	if !cluster.UserIntent.GetEnableLB() {
+		return result
+	}
+
+	pi := cluster.PlacementInfo
+	if pi == nil {
+		return result
+	}
+	for _, cloud := range pi.CloudList {
+		for _, region := range cloud.RegionList {
+			for _, az := range region.AzList {
+				if lbName := az.GetLbName(); lbName != "" {
+					result[region.GetCode()] = lbName
+				}
+			}
+		}
+	}
+
+	return result
+}
+
+func expandLBMap(raw map[string]interface{}) map[string]string {
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		result[k] = v.(string)
+	}
+	return result
+}


### PR DESCRIPTION
### Description
Adds support for a yba_universe_load_balancer resource which takes a UUID and region -> LB map and then associates those load balancers to the universe using update_lb_config API. Because Swagger annotation for configure params is not there VanillaClient had to be used. 


### Relations
[PLAT TICKET](https://yugabyte.atlassian.net/browse/PLAT-21020)
Once fixed, can remove need for VanillaClient

### References
https://github.com/yugabyte/byoc-setup/pull/54

This PR uses the provider resource to add load balancer to BYOC setup playground. 


### Output from Acceptance Testing


```
$ make testacc

...
```
