### PR TITLE
Fixing reconfigure to also run from installed package directory

### DIFF
--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -709,13 +709,19 @@ func getInstallCommands(
 }
 
 func getReconfigureCommands(version string) []string {
-	var reconfigureCommands = []string{"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml"}
+	folder := fmt.Sprintf("yba_installer_full-%s", version)
+	// yba-ctl uses a relative glob to find perf_advisor-*.tar.gz inside the
+	// extracted installer bundle, so it must run with that directory as CWD.
+	var reconfigureCmd string
 	if IsGAVersion(version) {
-		reconfigureCommands = append(reconfigureCommands, "sudo /opt/yba-ctl/yba-ctl reconfigure -f")
+		reconfigureCmd = fmt.Sprintf("cd ~/%s && sudo /opt/yba-ctl/yba-ctl reconfigure -f", folder)
 	} else {
-		reconfigureCommands = append(reconfigureCommands, "sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl reconfigure -f")
+		reconfigureCmd = fmt.Sprintf("cd ~/%s && sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl reconfigure -f", folder)
 	}
-	return reconfigureCommands
+	return []string{
+		"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml",
+		reconfigureCmd,
+	}
 }
 
 func getUpgradeCommands(version, os, arch string, skipPreflightCheckList *[]string) []string {


### PR DESCRIPTION
### Description
For things like enabling perf advisor after install reconfigure still needs to glob and find matching package paths. These packages are only in the initial downloaded software directory (/home/yugabyte/yba_installer_full/) so similar to how install/upgrade cd there before running yba-ctl, reconfigure should do the same thing. This will allow perf advisor to be enabled (and other reconfigs) to more safely run through terraform provider. 


### Relations


### References
https://github.com/yugabyte/byoc-setup/pull/52


### Testing
Run perf advisor enable + reconfigure through terraform provider 
