### PR TITLE
Add unit test CI workflow and fix test make target

### DIFF
--- a/.github/workflows/unit.yaml
+++ b/.github/workflows/unit.yaml
@@ -1,0 +1,37 @@
+name: Unit Tests
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - ".github/workflows/unit.yaml"
+  pull_request:
+    paths:
+      - "**/*.go"
+      - "**/go.mod"
+      - "**/go.sum"
+      - ".github/workflows/unit.yaml"
+
+jobs:
+  unit:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+        id: go
+
+      - name: Download dependencies
+        run: go mod download
+
+      - name: Run tests
+        run: make test

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -63,7 +63,7 @@ documents:
 # Run unit tests (no YBA or cloud credentials required)
 .PHONY: test
 test:
-	go test ./internal/provider/... -v -run "^Test[^Acc]" $(TESTARGS)
+	go test ./... -skip '^TestAcc' $(TESTARGS)
 
 # Run acceptance tests (requires YBA and cloud credentials - see CONTRIBUTING.md)
 .PHONY: testacc acctest


### PR DESCRIPTION
Add a Unit Tests workflow that runs `make test`.

Fix the `test` target, which previously only ran ./internal/provider/... and used a fragile `-run "^Test[^Acc]"` regex that silently excluded some unit tests. It now runs the whole module and excludes acceptance tests by name with `-skip '^TestAcc'`.
