### PR TITLE
[PLAT-21303] Fix yba_installer panic from go-scp v1.6.0 Connect() change

### DIFF
--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -101,13 +101,10 @@ func scpContent(ctx context.Context,
 	tflog.Info(ctx, fmt.Sprintf("Copying inline content (%d bytes) to remote host under "+
 		"filename %s", len(content), remoteFile))
 
+	// NewClientBySSH reuses the already-established SSH connection. Do NOT call
+	// c.Connect() afterwards: per go-scp's API it would dial a fresh session with
+	// an empty Host and nil ClientConfig, panicking on a nil-pointer deref.
 	c, err := scp.NewClientBySSH(sshClient)
-	if err != nil {
-		return err
-	}
-	defer c.Close()
-
-	err = c.Connect()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
yba_installer copies its inputs to the host over an already-open SSH connection via go-scp's NewClientBySSH, and then called the client's Connect(). The go-scp 1.2.0 to 1.6.0 bump removed Connect()'s "already have a session" early-return guard. On a NewClientBySSH client it now dials a fresh session with an empty host and a nil config, panicking with a nil-pointer dereference that crashes the provider on every fresh install.

Drop the Connect() call. The connection from NewClientBySSH is already ready to use. The bug is cloud-agnostic. The gcp and azure standing YBAs were installed before the bump, so AWS was simply the first fresh install after it. Verified by reproducing on a throwaway GCE VM (panic on the old code, clean upload on the fixed code).

Caused by 88a6a94b5483 ("[PLAT-21181] Bump Go dependencies...")

[PLAT-21181]: https://yugabyte.atlassian.net/browse/PLAT-21181?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ