### PR TITLE
[PLAT-21181] Run acceptance tests per-cloud, against each fixture's own YBA

### DIFF
--- a/.github/workflows/acctest-long.yml
+++ b/.github/workflows/acctest-long.yml
@@ -1,7 +1,11 @@
 name: Acceptance Tests (Long)
 # The long tier (TestAccLong*) runs multi-node universe deploys, ~15 min each.
-# Run on demand.
+# Runs automatically on pushes to main (post-merge), and on demand. Not run on
+# PRs — too slow and expensive to gate every PR.
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -110,16 +110,12 @@ acctest: install $(GOTESTSUM) acctest/env
 
 # Run the long acceptance tier (TestAccLong*). These deploy real multi-node
 # universes and take ~15 min each, so they stay out of `make acctest`. Same env
-# handling as acctest.
-#
-# For now this runs the GCP universe test only. The AWS/Azure long tests are
-# skipped until each cloud's universe test targets its own standing YBA (the
-# per-cloud-YBA wiring is a separate change); running them against the GCP YBA
-# is not a meaningful test.
+# handling as acctest. Each cloud's universe test targets its own standing YBA,
+# so all three (GCP/AWS/Azure) run.
 .PHONY: acctest-long
 acctest-long: install $(GOTESTSUM) acctest/env
 	@set -a; . ./acctest/env; set +a; \
-	TF_ACC=1 $(GOTESTSUM) -- -timeout 30m ./... -run '^TestAccLong' -skip '_(AWS|Azure)_'
+	TF_ACC=1 $(GOTESTSUM) -- -timeout 90m ./... -run '^TestAccLong'
 
 acctest/env:
 	$(MAKE) -C acctest env

--- a/acctest/aws/in-vars.tf
+++ b/acctest/aws/in-vars.tf
@@ -64,15 +64,20 @@ variable "operator_cidr_ranges" {
 # recent" tracks the newest published build. The same AMI is surfaced as
 # TF_VAR_AWS_AMI_ID for the provider tests' custom image bundles.
 variable "base_image" {
+  # name_pattern is the newer AMI (YBA VM boot image, TF_VAR_AWS_AMI_ID_NEW).
+  # prev_name_pattern is the older one (TF_VAR_AWS_AMI_ID_OLD). Both pinned per
+  # minor so they stay distinct. Bump as minors age out.
   description = "AlmaLinux 9 AMI lookup for the YBA VM and the image-bundle tests."
   type = object({
-    owner        = string
-    name_pattern = string
+    owner             = string
+    name_pattern      = string
+    prev_name_pattern = string
   })
   default = {
     # AlmaLinux OS Foundation's AWS account that publishes the official AMIs.
-    owner        = "764336703387"
-    name_pattern = "AlmaLinux OS 9*x86_64"
+    owner             = "764336703387"
+    name_pattern      = "AlmaLinux OS 9.8*x86_64"
+    prev_name_pattern = "AlmaLinux OS 9.7*x86_64"
   }
 }
 

--- a/acctest/aws/out-vars.tf
+++ b/acctest/aws/out-vars.tf
@@ -20,6 +20,8 @@ locals {
     TF_VAR_AWS_ZONE_SUBNET_ID='${aws_subnet.ybdb[0].id}'
     TF_VAR_AWS_ZONE_SUBNET_ID_2='${aws_subnet.ybdb[1].id}'
     TF_VAR_AWS_AMI_ID='${data.aws_ami.almalinux.id}'
+    TF_VAR_AWS_AMI_ID_NEW='${data.aws_ami.almalinux.id}'
+    TF_VAR_AWS_AMI_ID_OLD='${data.aws_ami.almalinux_prev.id}'
     TF_VAR_S3_BACKUP_LOCATION='s3://${aws_s3_bucket.backups.bucket}'
     TF_VAR_AWS_YBA_HOST='${aws_eip.yba.public_ip}'
     TF_VAR_AWS_YBA_API_KEY='${yba_customer_resource.customer.api_token}'

--- a/acctest/aws/yba.tf
+++ b/acctest/aws/yba.tf
@@ -61,6 +61,37 @@ data "aws_ami" "almalinux" {
   }
 }
 
+# A second, older AMI for the VM-image-upgrade universe test, which needs two
+# distinct images (upgrade old -> new). Pinned one minor back so it stays
+# different from data.aws_ami.almalinux (the newest). Exported as
+# TF_VAR_AWS_AMI_ID_OLD; the newest is TF_VAR_AWS_AMI_ID_NEW.
+data "aws_ami" "almalinux_prev" {
+  most_recent = true
+  owners      = [var.base_image.owner]
+
+  filter {
+    name   = "name"
+    values = [var.base_image.prev_name_pattern]
+  }
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+
+  # Fail loudly if the two patterns collapse to the same image (e.g. no newer
+  # minor exists yet), which would make the VM-image-upgrade test a no-op.
+  lifecycle {
+    postcondition {
+      condition     = self.id != data.aws_ami.almalinux.id
+      error_message = "base_image.prev_name_pattern resolved to the same AMI as base_image; pin it one minor back."
+    }
+  }
+}
+
 # EC2 key pair the installer's SSH key maps to.
 resource "aws_key_pair" "yba" {
   key_name   = "${var.prefix}-yba"

--- a/acctest/gcp/out-vars.tf
+++ b/acctest/gcp/out-vars.tf
@@ -6,8 +6,11 @@
 # sources it; `make -C acctest push-github-secrets` publishes it (CI writes it
 # back to acctest/env and sources it the same way).
 #
-# The YBA endpoint is exported as un-prefixed YBA_HOST/YBA_API_KEY — the shared
-# client read by the package init and used by every acceptance test.
+# The YBA endpoint is exported twice. Un-prefixed YBA_HOST/YBA_API_KEY is the
+# shared client read by the package init and used by the non-provider tests
+# (storage-config, cloud_provider, user, customer). The prefixed
+# TF_VAR_GCP_YBA_HOST/TF_VAR_GCP_YBA_API_KEY points the GCP provider tests at
+# this same YBA, mirroring how aws/azure target their own fixture YBAs.
 
 locals {
   test_env = <<-EOT
@@ -18,6 +21,8 @@ locals {
     TF_VAR_GCP_SUBNETWORK='${google_compute_subnetwork.ybdb.name}'
     TF_VAR_GCP_IMAGE='${data.google_compute_image.ybdb.self_link}'
     TF_VAR_GCS_BACKUP_LOCATION='gs://${google_storage_bucket.backups.name}'
+    TF_VAR_GCP_YBA_HOST='${google_compute_address.yba.address}'
+    TF_VAR_GCP_YBA_API_KEY='${yba_customer_resource.customer.api_token}'
     YBA_HOST='${google_compute_address.yba.address}'
     YBA_API_KEY='${yba_customer_resource.customer.api_token}'
   EOT

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -23,6 +23,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 
 	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
@@ -70,8 +71,13 @@ const (
 var (
 	// ProviderFactories maps schema.Provider to errors generated
 	ProviderFactories map[string]func() (*schema.Provider, error)
-	// APIClient variable
+	// APIClient is the shared YBA client (YBA_HOST), used by storage-config,
+	// user, and customer tests. Provider tests use APIClientForCloud instead.
 	APIClient *api.APIClient
+
+	// cloudClients caches one YBA client per cloud, keyed by cloud code.
+	cloudClients   = map[string]*api.APIClient{}
+	cloudClientsMu sync.Mutex
 )
 
 // getEnvMulti returns the first non-empty value from the given env var names
@@ -92,6 +98,56 @@ func TestHost() string {
 // TestAPIKey returns YBA_API_KEY or YB_API_KEY
 func TestAPIKey() string {
 	return getEnvMulti("YBA_API_KEY", "YB_API_KEY")
+}
+
+// CloudYBAHost returns TF_VAR_<CLOUD>_YBA_HOST (cloud is the upper-case code,
+// e.g. "AWS"). Each cloud has its own YBA. Provider tests must target the YBA
+// running on that cloud, because use_iam_instance_profile authenticates with
+// the YBA host's own instance role, which only exists on a same-cloud YBA.
+func CloudYBAHost(cloud string) string { return os.Getenv("TF_VAR_" + cloud + "_YBA_HOST") }
+
+// CloudYBAAPIKey returns TF_VAR_<CLOUD>_YBA_API_KEY. See CloudYBAHost.
+func CloudYBAAPIKey(cloud string) string { return os.Getenv("TF_VAR_" + cloud + "_YBA_API_KEY") }
+
+// APIClientForCloud builds and caches the YBA client for a cloud. Check and
+// Destroy helpers use it to read back state from the YBA the test wrote to.
+func APIClientForCloud(cloud string) (*api.APIClient, error) {
+	cloudClientsMu.Lock()
+	defer cloudClientsMu.Unlock()
+	if c, ok := cloudClients[cloud]; ok {
+		return c, nil
+	}
+	c, err := api.NewAPIClient(true, CloudYBAHost(cloud), CloudYBAAPIKey(cloud))
+	if err != nil {
+		return nil, err
+	}
+	cloudClients[cloud] = c
+	return c, nil
+}
+
+// YBAProviderBlock returns an HCL provider block plus its variable declarations,
+// pointing the provider at the cloud's YBA. Prepend it to a cloud's test config.
+//
+// The endpoint lives in the config rather than a process-global YBA_HOST. The
+// provider reads its endpoint at configure time, so a shared env var would race
+// across parallel tests targeting different YBAs.
+func YBAProviderBlock(cloud string) string {
+	return fmt.Sprintf(`
+variable "%[1]s_YBA_HOST" {
+  type = string
+}
+
+variable "%[1]s_YBA_API_KEY" {
+  type      = string
+  sensitive = true
+}
+
+provider "yba" {
+  host         = var.%[1]s_YBA_HOST
+  api_token    = var.%[1]s_YBA_API_KEY
+  enable_https = true
+}
+`, cloud)
 }
 
 // testPrefix isolates concurrent runs on a shared YBA. Honors TF_ACCTEST_PREFIX;
@@ -151,14 +207,21 @@ func RandomName(kind string) string {
 }
 
 func init() {
+	ProviderFactories = map[string]func() (*schema.Provider, error){
+		ybProviderName: func() (*schema.Provider, error) { return provider.New(), nil },
+	}
+	// Build the shared client only when a shared YBA is set, so importing this
+	// package never panics on an empty YBA_HOST. Tests that use the shared client
+	// gate on TestAccPreCheck (which fails fast on an empty host), so they never
+	// hit a nil client.
+	if TestHost() == "" {
+		return
+	}
 	c, err := api.NewAPIClient(true, TestHost(), TestAPIKey())
 	if err != nil {
 		panic(err)
 	}
 	APIClient = c
-	ProviderFactories = map[string]func() (*schema.Provider, error){
-		ybProviderName: func() (*schema.Provider, error) { return provider.New(), nil },
-	}
 }
 
 // SetupGCPCredentialsFile materializes the inline GCP SA key (TF_VAR_GCP_CREDENTIALS)
@@ -210,6 +273,18 @@ func TestAccPreCheckGCP(t *testing.T) {
 	for _, v := range requiredVars {
 		if os.Getenv(v) == "" {
 			t.Skipf("%s not set; skipping GCP acceptance tests", v)
+		}
+	}
+}
+
+// TestAccPreCheckCloudYBA skips unless the cloud's YBA endpoint is set
+// (TF_VAR_<CLOUD>_YBA_HOST and _API_KEY). Without a same-cloud fixture YBA the
+// tests would fail at apply, so they skip instead.
+func TestAccPreCheckCloudYBA(t *testing.T, cloud string) {
+	for _, suffix := range []string{"_YBA_HOST", "_YBA_API_KEY"} {
+		v := "TF_VAR_" + cloud + suffix
+		if os.Getenv(v) == "" {
+			t.Skipf("%s not set; skipping %s tests that target the %s YBA", v, cloud, cloud)
 		}
 	}
 }

--- a/internal/provider/aws/aws_provider_test.go
+++ b/internal/provider/aws/aws_provider_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	client "github.com/yugabyte/platform-go-client"
@@ -35,11 +34,11 @@ import (
 func TestAccAWSProvider_WithCredentials(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-aws-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("aws")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAWSProvider,
@@ -62,22 +61,16 @@ func TestAccAWSProvider_WithCredentials(t *testing.T) {
 
 // TestAccAWSProvider_WithIAM tests AWS provider creation with IAM instance profile
 func TestAccAWSProvider_WithIAM(t *testing.T) {
-	// use_iam_instance_profile makes YBA authenticate with the YBA host's own
-	// AWS instance role, which only exists when YBA runs on AWS. The shared YBA
-	// this suite targets is gcp-hosted, so skip. Enabled in a follow-up that
-	// routes the AWS tests to the AWS fixture YBA.
-	t.Skip("requires the YBA host to run on AWS with an IAM instance role")
-
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-aws-iam-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("aws-iam")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			// Uses an IAM instance profile rather than credentials, but the config
 			// still needs the AWS network env (SG/VPC/subnet) — gate on it so the
 			// test skips when AWS isn't configured instead of failing at plan.
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAWSProvider,
@@ -99,11 +92,11 @@ func TestAccAWSProvider_WithIAM(t *testing.T) {
 func TestAccAWSProvider_WithImageBundles(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-aws-ib-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("aws-ib")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAWSProvider,
@@ -128,13 +121,13 @@ func TestAccAWSProvider_WithImageBundles(t *testing.T) {
 func TestAccAWSProvider_Update(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-aws-upd-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("aws-upd")
 	rNameUpdated := rName + "-updated"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAWSProvider,
@@ -159,14 +152,18 @@ func TestAccAWSProvider_Update(t *testing.T) {
 }
 
 func testAccCheckDestroyAWSProvider(s *terraform.State) error {
-	conn := acctest.APIClient.YugawareClient
+	apiClient, err := acctest.APIClientForCloud("AWS")
+	if err != nil {
+		return err
+	}
+	conn := apiClient.YugawareClient
 
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "yba_aws_provider" {
 			continue
 		}
 		time.Sleep(60 * time.Second)
-		cUUID := acctest.APIClient.CustomerID
+		cUUID := apiClient.CustomerID
 		res, response, err := conn.CloudProvidersAPI.GetListOfProviders(context.Background(),
 			cUUID).Execute()
 		if err != nil {
@@ -196,8 +193,12 @@ func testAccCheckAWSProviderExists(
 			return errors.New("no ID is set for AWS provider resource")
 		}
 
-		conn := acctest.APIClient.YugawareClient
-		cUUID := acctest.APIClient.CustomerID
+		apiClient, err := acctest.APIClientForCloud("AWS")
+		if err != nil {
+			return err
+		}
+		conn := apiClient.YugawareClient
+		cUUID := apiClient.CustomerID
 		res, response, err := conn.CloudProvidersAPI.GetListOfProviders(context.Background(),
 			cUUID).Execute()
 		if err != nil {
@@ -216,7 +217,7 @@ func testAccCheckAWSProviderExists(
 }
 
 func awsProviderConfigBasic(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "AWS_SG_ID" {
   type        = string
   description = "AWS sg-id to run acceptance testing"
@@ -265,7 +266,7 @@ resource "yba_aws_provider" "test" {
 }
 
 func awsProviderConfigWithCredentials(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "AWS_SG_ID" {
   type = string
 }
@@ -311,7 +312,7 @@ resource "yba_aws_provider" "test" {
 }
 
 func awsProviderConfigWithIAM(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "AWS_SG_ID" {
   type = string
 }
@@ -345,7 +346,7 @@ resource "yba_aws_provider" "test" {
 }
 
 func awsProviderConfigWithImageBundles(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "AWS_SG_ID" {
   type = string
 }
@@ -409,11 +410,11 @@ resource "yba_aws_provider" "test" {
 func TestAccAWSProvider_MultiZoneWithRegionOverrides(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-aws-mz-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("aws-mz")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 			acctest.TestAccPreCheckAWSMultiZone(t)
 		},
 		ProviderFactories: acctest.ProviderFactories,
@@ -462,7 +463,7 @@ func TestAccAWSProvider_MultiZoneWithRegionOverrides(t *testing.T) {
 //	--image-bundle-region-override image-bundle-name=test-cli::region=... \
 //	--image-bundle-region-override image-bundle-name=test-cli::region=...
 func awsProviderConfigMultiZoneWithRegionOverrides(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "AWS_SG_ID" {
   type        = string
   description = "AWS Security Group ID"

--- a/internal/provider/azure/azure_provider_test.go
+++ b/internal/provider/azure/azure_provider_test.go
@@ -22,7 +22,6 @@ import (
 	"testing"
 	"time"
 
-	sdkacctest "github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	client "github.com/yugabyte/platform-go-client"
@@ -35,11 +34,11 @@ import (
 func TestAccAzureProvider_WithCredentials(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-azure-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("azure")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAzure(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AZURE")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAzureProvider,
@@ -62,11 +61,11 @@ func TestAccAzureProvider_WithCredentials(t *testing.T) {
 func TestAccAzureProvider_WithNetworkConfig(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-azure-net-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("azure-net")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAzure(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AZURE")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAzureProvider,
@@ -90,13 +89,13 @@ func TestAccAzureProvider_WithNetworkConfig(t *testing.T) {
 func TestAccAzureProvider_Update(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-azure-upd-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("azure-upd")
 	rNameUpdated := rName + "-updated"
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAzure(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AZURE")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAzureProvider,
@@ -124,11 +123,11 @@ func TestAccAzureProvider_Update(t *testing.T) {
 func TestAccAzureProvider_MultipleZones(t *testing.T) {
 	var provider client.Provider
 
-	rName := fmt.Sprintf("tf-acctest-azure-mz-%s", sdkacctest.RandString(12))
+	rName := acctest.RandomName("azure-mz")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAzure(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AZURE")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyAzureProvider,
@@ -146,14 +145,18 @@ func TestAccAzureProvider_MultipleZones(t *testing.T) {
 }
 
 func testAccCheckDestroyAzureProvider(s *terraform.State) error {
-	conn := acctest.APIClient.YugawareClient
+	apiClient, err := acctest.APIClientForCloud("AZURE")
+	if err != nil {
+		return err
+	}
+	conn := apiClient.YugawareClient
 
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "yba_azure_provider" {
 			continue
 		}
 		time.Sleep(60 * time.Second)
-		cUUID := acctest.APIClient.CustomerID
+		cUUID := apiClient.CustomerID
 		res, response, err := conn.CloudProvidersAPI.GetListOfProviders(context.Background(),
 			cUUID).Execute()
 		if err != nil {
@@ -183,8 +186,12 @@ func testAccCheckAzureProviderExists(
 			return errors.New("no ID is set for Azure provider resource")
 		}
 
-		conn := acctest.APIClient.YugawareClient
-		cUUID := acctest.APIClient.CustomerID
+		apiClient, err := acctest.APIClientForCloud("AZURE")
+		if err != nil {
+			return err
+		}
+		conn := apiClient.YugawareClient
+		cUUID := apiClient.CustomerID
 		res, response, err := conn.CloudProvidersAPI.GetListOfProviders(context.Background(),
 			cUUID).Execute()
 		if err != nil {
@@ -203,7 +210,7 @@ func testAccCheckAzureProviderExists(
 }
 
 func azureProviderConfigBasic(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AZURE") + fmt.Sprintf(`
 variable "AZURE_SUBSCRIPTION_ID" {
   type        = string
   description = "Azure subscription ID"
@@ -264,7 +271,7 @@ resource "yba_azure_provider" "test" {
 }
 
 func azureProviderConfigWithCredentials(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AZURE") + fmt.Sprintf(`
 variable "AZURE_SUBSCRIPTION_ID" {
   type = string
 }
@@ -318,7 +325,7 @@ resource "yba_azure_provider" "test" {
 }
 
 func azureProviderConfigWithNetworkConfig(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AZURE") + fmt.Sprintf(`
 variable "AZURE_SUBSCRIPTION_ID" {
   type = string
 }
@@ -384,7 +391,7 @@ resource "yba_azure_provider" "test" {
 }
 
 func azureProviderConfigMultipleZones(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AZURE") + fmt.Sprintf(`
 variable "AZURE_SUBSCRIPTION_ID" {
   type = string
 }

--- a/internal/provider/gcp/gcp_provider_test.go
+++ b/internal/provider/gcp/gcp_provider_test.go
@@ -38,8 +38,8 @@ func TestAccGCPProvider_WithCredentials(t *testing.T) {
 	rName := acctest.RandomName("gcp")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckGCP(t)
+			acctest.TestAccPreCheckCloudYBA(t, "GCP")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyGCPProvider,
@@ -67,7 +67,7 @@ func TestAccGCPProvider_WithHostCredentials(t *testing.T) {
 	rName := acctest.RandomName("gcp-host")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
+			acctest.TestAccPreCheckCloudYBA(t, "GCP")
 			// No GCP credential check - using host credentials
 		},
 		ProviderFactories: acctest.ProviderFactories,
@@ -99,8 +99,8 @@ func TestAccGCPProvider_WithSharedVPC(t *testing.T) {
 	rName := acctest.RandomName("gcp-vpc")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckGCP(t)
+			acctest.TestAccPreCheckCloudYBA(t, "GCP")
 			if os.Getenv("TF_VAR_GCP_SHARED_VPC_PROJECT_ID") == "" {
 				t.Skip("TF_VAR_GCP_SHARED_VPC_PROJECT_ID not set; skipping Shared VPC test")
 			}
@@ -130,8 +130,8 @@ func TestAccGCPProvider_Update(t *testing.T) {
 
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckGCP(t)
+			acctest.TestAccPreCheckCloudYBA(t, "GCP")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyGCPProvider,
@@ -162,8 +162,8 @@ func TestAccGCPProvider_WithFirewallTags(t *testing.T) {
 	rName := acctest.RandomName("gcp-fw")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckGCP(t)
+			acctest.TestAccPreCheckCloudYBA(t, "GCP")
 		},
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckDestroyGCPProvider,
@@ -181,8 +181,12 @@ func TestAccGCPProvider_WithFirewallTags(t *testing.T) {
 }
 
 func testAccCheckDestroyGCPProvider(s *terraform.State) error {
-	conn := acctest.APIClient.YugawareClient
-	cUUID := acctest.APIClient.CustomerID
+	apiClient, err := acctest.APIClientForCloud("GCP")
+	if err != nil {
+		return err
+	}
+	conn := apiClient.YugawareClient
+	cUUID := apiClient.CustomerID
 
 	for _, r := range s.RootModule().Resources {
 		if r.Type != "yba_gcp_provider" {
@@ -235,8 +239,12 @@ func testAccCheckGCPProviderExists(
 			return errors.New("no ID is set for GCP provider resource")
 		}
 
-		conn := acctest.APIClient.YugawareClient
-		cUUID := acctest.APIClient.CustomerID
+		apiClient, err := acctest.APIClientForCloud("GCP")
+		if err != nil {
+			return err
+		}
+		conn := apiClient.YugawareClient
+		cUUID := apiClient.CustomerID
 		res, response, err := conn.CloudProvidersAPI.GetListOfProviders(context.Background(),
 			cUUID).Execute()
 		if err != nil {
@@ -255,7 +263,7 @@ func testAccCheckGCPProviderExists(
 }
 
 func gcpProviderConfigBasic(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCP_VPC_NETWORK" {
   type        = string
   description = "GCP VPC network to run acceptance testing"
@@ -298,7 +306,7 @@ resource "yba_gcp_provider" "test" {
 }
 
 func gcpProviderConfigWithCredentials(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCP_VPC_NETWORK" {
   type = string
 }
@@ -338,7 +346,7 @@ resource "yba_gcp_provider" "test" {
 }
 
 func gcpProviderConfigWithHostCredentials(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCP_VPC_NETWORK" {
   type = string
 }
@@ -373,7 +381,7 @@ resource "yba_gcp_provider" "test" {
 }
 
 func gcpProviderConfigWithSharedVPC(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCP_VPC_NETWORK" {
   type = string
 }
@@ -419,7 +427,7 @@ resource "yba_gcp_provider" "test" {
 }
 
 func gcpProviderConfigWithFirewallTags(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCP_VPC_NETWORK" {
   type = string
 }

--- a/internal/storageconfig/azure_storage_config_test.go
+++ b/internal/storageconfig/azure_storage_config_test.go
@@ -83,7 +83,8 @@ func TestAccAzureStorageConfig_Update(t *testing.T) {
 }
 
 func testAccPreCheckAzureStorage(t *testing.T) {
-	acctest.TestAccPreCheck(t)
+	// Azure storage configs run against the Azure fixture YBA.
+	acctest.TestAccPreCheckCloudYBA(t, "AZURE")
 
 	requiredVars := []string{
 		"TF_VAR_AZURE_BACKUP_LOCATION",
@@ -98,7 +99,7 @@ func testAccPreCheckAzureStorage(t *testing.T) {
 }
 
 func testAccAzureStorageConfig(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AZURE") + fmt.Sprintf(`
 variable "AZURE_BACKUP_LOCATION" {
   type = string
 }

--- a/internal/storageconfig/gcs_storage_config_test.go
+++ b/internal/storageconfig/gcs_storage_config_test.go
@@ -53,11 +53,11 @@ func TestAccGCSStorageConfig_Basic(t *testing.T) {
 
 // TestAccGCSStorageConfig_IAM tests GCS storage config with GCP IAM (workload identity)
 func TestAccGCSStorageConfig_IAM(t *testing.T) {
-	t.Skip("GCP IAM test requires running on a GKE cluster with workload identity")
-
 	rName := acctest.RandomName("gcs-iam")
 
 	resource.Test(t, resource.TestCase{
+		// use_gcp_iam makes YBA reach GCS with the YBA host's own service account.
+		// testAccPreCheckGCS already targets the GCP fixture YBA.
 		PreCheck:          func() { testAccPreCheckGCS(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStorageConfigDestroy,
@@ -111,7 +111,8 @@ func TestAccGCSStorageConfig_Update(t *testing.T) {
 }
 
 func testAccPreCheckGCS(t *testing.T) {
-	acctest.TestAccPreCheck(t)
+	// GCS storage configs run against the GCP fixture YBA.
+	acctest.TestAccPreCheckCloudYBA(t, "GCP")
 
 	requiredVars := []string{
 		"TF_VAR_GCS_BACKUP_LOCATION",
@@ -126,7 +127,7 @@ func testAccPreCheckGCS(t *testing.T) {
 }
 
 func testAccGCSStorageConfigWithCredentials(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCS_BACKUP_LOCATION" {
   type = string
 }
@@ -145,7 +146,7 @@ resource "yba_gcs_storage_config" "test" {
 }
 
 func testAccGCSStorageConfigWithIAM(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("GCP") + fmt.Sprintf(`
 variable "GCS_BACKUP_LOCATION" {
   type = string
 }

--- a/internal/storageconfig/s3_storage_config_test.go
+++ b/internal/storageconfig/s3_storage_config_test.go
@@ -55,12 +55,12 @@ func TestAccS3StorageConfig_Basic(t *testing.T) {
 
 // TestAccS3StorageConfig_IAM tests S3 storage config with IAM instance profile
 func TestAccS3StorageConfig_IAM(t *testing.T) {
-	t.Skip("IAM instance profile test requires running on an AWS instance with IAM role")
-
 	rName := fmt.Sprintf("tf-acctest-s3-iam-%s", sdkacctest.RandString(8))
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.TestAccPreCheck(t) },
+		// use_iam_instance_profile makes YBA reach S3 with the YBA host's own AWS
+		// instance role. testAccPreCheckS3 already targets the AWS fixture YBA.
+		PreCheck:          func() { testAccPreCheckS3(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccCheckStorageConfigDestroy,
 		Steps: []resource.TestStep{
@@ -113,7 +113,8 @@ func TestAccS3StorageConfig_Update(t *testing.T) {
 }
 
 func testAccPreCheckS3(t *testing.T) {
-	acctest.TestAccPreCheck(t)
+	// S3 storage configs run against the AWS fixture YBA.
+	acctest.TestAccPreCheckCloudYBA(t, "AWS")
 
 	requiredVars := []string{
 		"TF_VAR_S3_BACKUP_LOCATION",
@@ -148,7 +149,7 @@ func testAccCheckStorageConfigDestroy(s *terraform.State) error {
 }
 
 func testAccS3StorageConfigWithCredentials(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "S3_BACKUP_LOCATION" {
   type = string
 }
@@ -175,7 +176,7 @@ resource "yba_s3_storage_config" "test" {
 }
 
 func testAccS3StorageConfigWithIAM(name string) string {
-	return fmt.Sprintf(`
+	return acctest.YBAProviderBlock("AWS") + fmt.Sprintf(`
 variable "S3_BACKUP_LOCATION" {
   type = string
 }

--- a/internal/universe/universe_test.go
+++ b/internal/universe/universe_test.go
@@ -36,23 +36,23 @@ func TestAccLong_Universe_GCP_UpdatePrimaryNodes(t *testing.T) {
 	rName := acctest.RandomName("gcp-universe")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckGCP(t)
+			acctest.TestAccPreCheckCloudYBA(t, "GCP")
 		},
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckDestroyProviderAndUniverse,
+		CheckDestroy:      testAccCheckDestroyProviderAndUniverse("GCP"),
 		Steps: []resource.TestStep{
 			{
 				Config: universeGcpConfigWithNodes(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.gcp", &universe),
+					testAccCheckUniverseExists("GCP", "yba_universe.gcp", &universe),
 					testAccCheckNumNodes(&universe, 3),
 				),
 			},
 			{
 				Config: universeGcpConfigWithNodes(rName, 4),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.gcp", &universe),
+					testAccCheckUniverseExists("GCP", "yba_universe.gcp", &universe),
 					testAccCheckNumNodes(&universe, 4),
 				),
 			},
@@ -66,23 +66,23 @@ func TestAccLong_Universe_AWS_UpdatePrimaryNodes(t *testing.T) {
 	rName := acctest.RandomName("aws-universe")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 		},
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckDestroyProviderAndUniverse,
+		CheckDestroy:      testAccCheckDestroyProviderAndUniverse("AWS"),
 		Steps: []resource.TestStep{
 			{
 				Config: universeAwsConfigWithNodes(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.aws", &universe),
+					testAccCheckUniverseExists("AWS", "yba_universe.aws", &universe),
 					testAccCheckNumNodes(&universe, 3),
 				),
 			},
 			{
 				Config: universeAwsConfigWithNodes(rName, 4),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.aws", &universe),
+					testAccCheckUniverseExists("AWS", "yba_universe.aws", &universe),
 					testAccCheckNumNodes(&universe, 4),
 				),
 			},
@@ -96,23 +96,23 @@ func TestAccLong_Universe_Azure_UpdatePrimaryNodes(t *testing.T) {
 	rName := acctest.RandomName("azu-universe")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAzure(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AZURE")
 		},
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckDestroyProviderAndUniverse,
+		CheckDestroy:      testAccCheckDestroyProviderAndUniverse("AZURE"),
 		Steps: []resource.TestStep{
 			{
 				Config: universeAzureConfigWithNodes(rName, 3),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.azu", &universe),
+					testAccCheckUniverseExists("AZURE", "yba_universe.azu", &universe),
 					testAccCheckNumNodes(&universe, 3),
 				),
 			},
 			{
 				Config: universeAzureConfigWithNodes(rName, 4),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.azu", &universe),
+					testAccCheckUniverseExists("AZURE", "yba_universe.azu", &universe),
 					testAccCheckNumNodes(&universe, 4),
 				),
 			},
@@ -120,55 +120,61 @@ func TestAccLong_Universe_Azure_UpdatePrimaryNodes(t *testing.T) {
 	})
 }
 
-func testAccCheckDestroyProviderAndUniverse(s *terraform.State) error {
-	conn := acctest.APIClient.YugawareClient
+func testAccCheckDestroyProviderAndUniverse(cloud string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		apiClient, err := acctest.APIClientForCloud(cloud)
+		if err != nil {
+			return err
+		}
+		conn := apiClient.YugawareClient
+		cUUID := apiClient.CustomerID
 
-	for _, r := range s.RootModule().Resources {
-		switch r.Type {
-		case "yba_universe":
-			cUUID := acctest.APIClient.CustomerID
-			_, _, err := conn.UniverseManagementAPI.GetUniverse(context.Background(), cUUID,
-				r.Primary.ID).Execute()
-			// A 404 means the universe is gone (destroyed) — that is the success
-			// case. Only a successful GET means it still exists.
-			if err == nil {
-				return errors.New("Universe resource is not destroyed")
-			}
-		case "yba_cloud_provider":
-			// Provider deletion is async; poll until it disappears rather than
-			// sleeping a fixed interval (which can false-fail and leak the
-			// provider if deletion runs long).
-			cUUID := acctest.APIClient.CustomerID
-			deadline := time.Now().Add(5 * time.Minute)
-			for {
-				res, response, err := conn.CloudProvidersAPI.GetListOfProviders(
-					context.Background(), cUUID).Execute()
-				if err != nil {
-					return utils.ErrorFromHTTPResponse(response, err, utils.TestEntity,
-						"Universe", "Read - Cloud Provider")
+		for _, r := range s.RootModule().Resources {
+			switch r.Type {
+			case "yba_universe":
+				_, _, err := conn.UniverseManagementAPI.GetUniverse(context.Background(), cUUID,
+					r.Primary.ID).Execute()
+				// A 404 means the universe is gone (destroyed) — that is the success
+				// case. Only a successful GET means it still exists.
+				if err == nil {
+					return errors.New("Universe resource is not destroyed")
 				}
-				found := false
-				for _, p := range res {
-					if *p.Uuid == r.Primary.ID {
-						found = true
+			case "yba_cloud_provider":
+				// Provider deletion is async; poll until it disappears rather than
+				// sleeping a fixed interval (which can false-fail and leak the
+				// provider if deletion runs long).
+				deadline := time.Now().Add(5 * time.Minute)
+				for {
+					res, response, err := conn.CloudProvidersAPI.GetListOfProviders(
+						context.Background(), cUUID).Execute()
+					if err != nil {
+						return utils.ErrorFromHTTPResponse(response, err, utils.TestEntity,
+							"Universe", "Read - Cloud Provider")
+					}
+					found := false
+					for _, p := range res {
+						if *p.Uuid == r.Primary.ID {
+							found = true
+							break
+						}
+					}
+					if !found {
 						break
 					}
+					if time.Now().After(deadline) {
+						return errors.New("Cloud provider is not destroyed")
+					}
+					time.Sleep(10 * time.Second)
 				}
-				if !found {
-					break
-				}
-				if time.Now().After(deadline) {
-					return errors.New("Cloud provider is not destroyed")
-				}
-				time.Sleep(10 * time.Second)
 			}
 		}
-	}
 
-	return nil
+		return nil
+	}
 }
 
-func testAccCheckUniverseExists(name string, universe *client.UniverseResp) resource.TestCheckFunc {
+func testAccCheckUniverseExists(
+	cloud, name string, universe *client.UniverseResp) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		r, ok := s.RootModule().Resources[name]
 		if !ok {
@@ -178,8 +184,12 @@ func testAccCheckUniverseExists(name string, universe *client.UniverseResp) reso
 			return errors.New("no ID is set for universe resource")
 		}
 
-		conn := acctest.APIClient.YugawareClient
-		cUUID := acctest.APIClient.CustomerID
+		apiClient, err := acctest.APIClientForCloud(cloud)
+		if err != nil {
+			return err
+		}
+		conn := apiClient.YugawareClient
+		cUUID := apiClient.CustomerID
 		res, response, err := conn.UniverseManagementAPI.GetUniverse(context.Background(), cUUID,
 			r.Primary.ID).Execute()
 		if err != nil {
@@ -203,17 +213,17 @@ func testAccCheckNumNodes(universe *client.UniverseResp, expected int32) resourc
 }
 
 func universeGcpConfigWithNodes(name string, nodes int) string {
-	return cloudProviderGCPConfig(name+"-provider") +
+	return acctest.YBAProviderBlock("GCP") + cloudProviderGCPConfig(name+"-provider") +
 		universeConfigWithProviderWithNodes("gcp", name, nodes)
 }
 
 func universeAwsConfigWithNodes(name string, nodes int) string {
-	return cloudProviderAWSConfig(name+"-provider") +
+	return acctest.YBAProviderBlock("AWS") + cloudProviderAWSConfig(name+"-provider") +
 		universeConfigWithProviderWithNodes("aws", name, nodes)
 }
 
 func universeAzureConfigWithNodes(name string, nodes int) string {
-	return cloudProviderAzureConfig(name+"-provider") +
+	return acctest.YBAProviderBlock("AZURE") + cloudProviderAzureConfig(name+"-provider") +
 		universeConfigWithProviderWithNodes("azu", name, nodes)
 }
 
@@ -275,13 +285,20 @@ func getUniverseStorageType(p string) string {
 }
 
 func getUniverseInstanceType(p string) string {
+	// All clouds use a current-gen, 2-vCPU instance — YugabyteDB's documented
+	// minimum is 2 cores / 2 GB RAM, and these tests only need a node to come up.
 	switch p {
 	case "gcp":
 		return "n2-standard-2"
 	case "aws":
-		return "c5.large"
+		return "c6i.large"
 	}
-	return "Standard_D4s_v3"
+	// Azure: current-gen v5. The v6 D-series fails YBA node provisioning
+	// (YNPProvisioning) in 2025.2.x — its NVMe-only data-disk layout differs from
+	// the SCSI layout the provisioner expects — so v5 is the newest size YBA can
+	// bring up here. Its Dsv5 family quota is separate from the Dsv3 the standing
+	// fixture YBA VM consumes.
+	return "Standard_D2s_v5"
 }
 
 func cloudProviderGCPConfig(name string) string {
@@ -404,24 +421,24 @@ func TestAccLong_Universe_AWS_VMImageUpgrade(t *testing.T) {
 	rName := acctest.RandomName("aws-universe")
 	resource.ParallelTest(t, resource.TestCase{
 		PreCheck: func() {
-			acctest.TestAccPreCheck(t)
 			acctest.TestAccPreCheckAWS(t)
+			acctest.TestAccPreCheckCloudYBA(t, "AWS")
 		},
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckDestroyProviderAndUniverse,
+		CheckDestroy:      testAccCheckDestroyProviderAndUniverse("AWS"),
 		Steps: []resource.TestStep{
 			{
 				Config: universeAwsConfigWithImageBundle(rName,
 					"${yba_aws_provider.aws.image_bundles[0].uuid}"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.aws", &universeBefore),
+					testAccCheckUniverseExists("AWS", "yba_universe.aws", &universeBefore),
 				),
 			},
 			{
 				Config: universeAwsConfigWithImageBundle(rName,
 					"${yba_aws_provider.aws.image_bundles[1].uuid}"),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckUniverseExists("yba_universe.aws", &universeAfter),
+					testAccCheckUniverseExists("AWS", "yba_universe.aws", &universeAfter),
 					testAccCheckImageBundleUpdated(&universeBefore, &universeAfter),
 				),
 			},
@@ -465,7 +482,8 @@ func testAccCheckImageBundleUpdated(before *client.UniverseResp,
 }
 
 func universeAwsConfigWithImageBundle(name string, imageBundleUUID string) string {
-	return cloudProviderAWSConfigForVMImageUpgrade(name+"-provider") +
+	return acctest.YBAProviderBlock("AWS") +
+		cloudProviderAWSConfigForVMImageUpgrade(name+"-provider") +
 		universeConfigWithProviderWithImageBundle("aws", name, imageBundleUUID)
 }
 
@@ -562,7 +580,6 @@ func universeConfigWithProviderWithImageBundle(p string, name string,
             cluster_type = "PRIMARY"
             user_intent {
                 universe_name      = "%s"
-                provider_type      = "%s"
                 provider           = yba_aws_provider.%s.id
                 region_list        = yba_aws_provider.%s.regions[*].uuid
                 num_nodes          = 1
@@ -593,12 +610,11 @@ func universeConfigWithProviderWithImageBundle(p string, name string,
             cluster_type = "ASYNC"
             user_intent {
                 universe_name      = "%s"
-                provider_type      = "%s"
                 provider           = yba_aws_provider.%s.id
                 region_list        = yba_aws_provider.%s.regions[*].uuid
                 num_nodes          = 1
                 replication_factor = 1
-                instance_type      = "c5.large"
+                instance_type      = "%s"
                 image_bundle_uuid  = "%s"
                 device_info {
                     num_volumes  = 1
@@ -613,6 +629,11 @@ func universeConfigWithProviderWithImageBundle(p string, name string,
         }
         communication_ports {}
     }
-`, p, p, name, p, p, p, getUniverseInstanceType(p), imageBundleUUID, getUniverseStorageType(p), p,
-		name, p, p, p, imageBundleUUID, getUniverseStorageType(p), p) // Map the new ASYNC arguments
+`,
+		// PRIMARY cluster
+		p, p, name, p, p, getUniverseInstanceType(p), imageBundleUUID,
+		getUniverseStorageType(p), p,
+		// ASYNC cluster
+		name, p, p, getUniverseInstanceType(p), imageBundleUUID,
+		getUniverseStorageType(p), p)
 }


### PR DESCRIPTION
## Summary

The acceptance suite ran every test against a single shared YBA (`YBA_HOST`, a
gcp-hosted control plane). That works for credential-based tests because the
cloud credentials travel in the request, but not for host-identity paths
(`use_iam_instance_profile`, `use_gcp_iam`, universe provisioning), where the
YBA host itself must run on that cloud. Those tests were skipped.

This routes each cloud's tests at that cloud's own fixture YBA, carrying the
endpoint in the Terraform config (a per-cloud `provider "yba"` block) rather
than a process-global `YBA_HOST`, so clouds run in one parallel pass without
racing on the provider's configure-time env read.

## Commits

1. **Add per-cloud YBA routing helpers** — `YBAProviderBlock`,
   `APIClientForCloud`, `TestAccPreCheckCloudYBA`, lazy shared-client init, and a
   resource-name prefix cap (long branch names overflowed YBA's varchar(100)
   access-key identifiers).
2. **Route provider acctests** — AWS/Azure/GCP provider tests target their
   fixture YBAs. Re-enables `TestAccAWSProvider_WithIAM`. The gcp fixture exports
   both the un-prefixed `YBA_HOST` (shared client) and `TF_VAR_GCP_YBA_HOST`.
3. **Storage-config per-cloud + IAM** — S3 on AWS, GCS on GCP, Azure on Azure
   (NFS stays shared). Unskips `TestAccS3StorageConfig_IAM` and
   `TestAccGCSStorageConfig_IAM`.
4. **AWS fixture older AMI** — resolve a second, older AlmaLinux AMI for the
   VM-image-upgrade test and export `TF_VAR_AWS_AMI_ID_OLD` / `_NEW`.
5. **Universe long tests per-cloud + on main** — route GCP/AWS/Azure universe
   tests, drop the `_(AWS|Azure)_` skip, trigger `acctest-long` on pushes to main
   (still off PRs), and use current-gen 2-vCPU node sizes.

## Routing

Provider, storage, and universe tests → their cloud's fixture YBA. Shared YBA
(`YBA_HOST`, = the GCP fixture YBA) still serves `user`, `customer`, and NFS.

## Test plan

**Short tier** (gates this PR) — green: AWS/Azure/GCP provider suites (incl.
`TestAccAWSProvider_WithIAM`) and all storage configs (S3/GCS/Azure/NFS
`_Basic`/`_Update` + both IAM variants) pass against their per-cloud fixture YBAs.

**Long tier** (`acctest-long`, dispatched on the PR branch —
[run 27681218692](https://github.com/yugabyte/terraform-provider-yba/actions/runs/27681218692))
— all universe deploys pass against their per-cloud YBAs:

```
PASS internal/universe.TestAccLong_Universe_AWS_UpdatePrimaryNodes   (562.68s)
PASS internal/universe.TestAccLong_Universe_GCP_UpdatePrimaryNodes   (712.09s)
PASS internal/universe.TestAccLong_Universe_Azure_UpdatePrimaryNodes (836.17s)
PASS internal/universe.TestAccLong_Universe_AWS_VMImageUpgrade       (865.91s)
DONE 4 tests in 871.022s
```

The `ACCTEST_ENV` CI secret was updated with `TF_VAR_GCP_YBA_HOST` /
`TF_VAR_GCP_YBA_API_KEY` and the VM-image-upgrade AMIs so the routed tests run
rather than skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)