### PR TITLE
Separating out pre work for telemetry provider landing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,3 @@ local/
 
 # Test env written by `make acctest-env` (secret: SA key + API token)
 acctest/env*
-
-# SSH keypair the azure fixture generates in-apply when ssh_private_key_file=""
-acctest/*/.ssh-*

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -110,16 +110,12 @@ acctest: install $(GOTESTSUM) acctest/env
 
 # Run the long acceptance tier (TestAccLong*). These deploy real multi-node
 # universes and take ~15 min each, so they stay out of `make acctest`. Same env
-# handling as acctest.
-#
-# For now this runs the GCP universe test only. The AWS/Azure long tests are
-# skipped until each cloud's universe test targets its own standing YBA (the
-# per-cloud-YBA wiring is a separate change); running them against the GCP YBA
-# is not a meaningful test.
+# handling as acctest. Each cloud's universe test targets its own standing YBA,
+# so all three (GCP/AWS/Azure) run.
 .PHONY: acctest-long
 acctest-long: install $(GOTESTSUM) acctest/env
 	@set -a; . ./acctest/env; set +a; \
-	TF_ACC=1 $(GOTESTSUM) -- -timeout 160m ./... -run '^TestAccLong' -skip '_(AWS|Azure)_'
+	TF_ACC=1 $(GOTESTSUM) -- -timeout 90m ./... -run '^TestAccLong'
 
 acctest/env:
 	$(MAKE) -C acctest env

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -112,6 +112,12 @@ acctest: install $(GOTESTSUM) acctest/env
 # universes and take ~15 min each, so they stay out of `make acctest`. Same env
 # handling as acctest.
 #
+# -timeout must comfortably exceed one test's create + update + delete (the
+# universe resource alone allows 60m create / 60m update / 30m delete). If the
+# go-test binary timeout fires mid-test the binary is SIGKILL'd, so the SDK's
+# automatic terraform destroy never runs and the universe (whose nodes are not
+# TF-managed) leaks. 160m covers the worst case and stays under the 180m CI job.
+#
 # For now this runs the GCP universe test only. The AWS/Azure long tests are
 # skipped until each cloud's universe test targets its own standing YBA (the
 # per-cloud-YBA wiring is a separate change); running them against the GCP YBA
@@ -119,7 +125,7 @@ acctest: install $(GOTESTSUM) acctest/env
 .PHONY: acctest-long
 acctest-long: install $(GOTESTSUM) acctest/env
 	@set -a; . ./acctest/env; set +a; \
-	TF_ACC=1 $(GOTESTSUM) -- -timeout 30m ./... -run '^TestAccLong' -skip '_(AWS|Azure)_'
+	TF_ACC=1 $(GOTESTSUM) -- -timeout 160m ./... -run '^TestAccLong' -skip '_(AWS|Azure)_'
 
 acctest/env:
 	$(MAKE) -C acctest env

--- a/acctest/aws/in-vars.tf
+++ b/acctest/aws/in-vars.tf
@@ -87,12 +87,6 @@ variable "yba_instance_type" {
   default     = "m5.xlarge"
 }
 
-variable "ssh_private_key_file" {
-  description = "Path to the SSH private key used to install YBA; its .pub is added to the VM. ~ is expanded. Mirrors gcp/azure: an existing key is required because yba_installer validates the private-key path exists at plan time, so a key generated in the same apply cannot satisfy it. (Setting this to \"\" triggers in-apply key generation, which fails that plan-time check.)"
-  type        = string
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "yba_admin_user" {
   description = "Admin (SSH) user on the YBA VM. The installer connects as this user. AlmaLinux AMIs default to ec2-user."
   type        = string

--- a/acctest/aws/providers.tf
+++ b/acctest/aws/providers.tf
@@ -33,10 +33,6 @@ terraform {
       source  = "hashicorp/tls"
       version = ">= 4.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 2.0"
-    }
     yba = {
       source = "yugabyte/yba"
     }

--- a/acctest/aws/terraform.tfvars
+++ b/acctest/aws/terraform.tfvars
@@ -10,7 +10,7 @@ aws_profile = "byoc-dev"
 
 # YBA version to install on the acceptance-test VM. Must be a valid downloadable
 # build (provider requires >= 2024.2.0.0). Update to the build you want to test.
-yba_version = "2025.2.3.1-b2"
+yba_version = "2.31.0.0-b164"
 
 vpc_cidr        = "10.0.0.0/16"
 yba_subnet_cidr = "10.0.1.0/24"

--- a/acctest/aws/yba.tf
+++ b/acctest/aws/yba.tf
@@ -7,37 +7,20 @@
 # output so `make acctest` just consumes it. Tear down with the base.
 # Mirrors acctest/gcp and acctest/azure.
 
-# SSH key for the installer. If var.ssh_private_key_file is set, reuse that
-# existing key (mirrors gcp/azure); otherwise generate a fresh RSA key and
-# write both halves into the working directory so the installer can read the
-# private half over the filesystem.
 locals {
-  generate_ssh_key     = var.ssh_private_key_file == ""
-  generated_key_path   = "${path.module}/.ssh-yba"
-  ssh_private_key_file = local.generate_ssh_key ? local.generated_key_path : pathexpand(var.ssh_private_key_file)
-  ssh_public_key_file  = "${local.ssh_private_key_file}.pub"
-  ssh_public_key       = local.generate_ssh_key ? tls_private_key.yba[0].public_key_openssh : file(local.ssh_public_key_file)
-  yba_ssh_host         = aws_eip.yba.public_ip
+  yba_ssh_host = aws_eip.yba.public_ip
 }
 
+# Dedicated SSH keypair for the standing YBA VM, generated once and kept in the
+# shared remote state (alongside random_password.customer). The public half goes
+# on the VM and the private half is fed to the installer inline via
+# ssh_private_key, so applies don't depend on (or drift against) any developer's
+# ~/.ssh keypair. Passing it inline (not as a file path) sidesteps the
+# installer's plan-time file-existence check, which a key generated in the same
+# apply can't satisfy.
 resource "tls_private_key" "yba" {
-  count     = local.generate_ssh_key ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
-}
-
-resource "local_sensitive_file" "ssh_private_key" {
-  count           = local.generate_ssh_key ? 1 : 0
-  content         = tls_private_key.yba[0].private_key_openssh
-  filename        = local.generated_key_path
-  file_permission = "0600"
-}
-
-resource "local_file" "ssh_public_key" {
-  count           = local.generate_ssh_key ? 1 : 0
-  content         = tls_private_key.yba[0].public_key_openssh
-  filename        = "${local.generated_key_path}.pub"
-  file_permission = "0644"
 }
 
 # Resolve base_image (an owner + name pattern) to a concrete AMI. Exposed as
@@ -64,7 +47,7 @@ data "aws_ami" "almalinux" {
 # EC2 key pair the installer's SSH key maps to.
 resource "aws_key_pair" "yba" {
   key_name   = "${var.prefix}-yba"
-  public_key = local.ssh_public_key
+  public_key = tls_private_key.yba.public_key_openssh
 }
 
 # Stable public IP for the YBA VM: a fixed address for the installer (SSH) and
@@ -129,16 +112,16 @@ resource "random_password" "customer" {
   override_special = "!#$%*-_"
 }
 
-# Install YugabyteDB Anywhere on the VM over SSH. The provider takes file paths
-# (validated to exist at plan time): the SSH key is the generated/provided
-# private half, the license is at the repo root, and yba-ctl.yml is in
-# acctest/resources. The installer connects as the VM admin user.
+# Install YugabyteDB Anywhere on the VM over SSH. The SSH key is the generated
+# keypair (passed inline); the license file is at the repo root and yba-ctl.yml
+# is in acctest/resources (both validated to exist at plan time). The installer
+# connects as the VM admin user.
 resource "yba_installer" "install" {
   provider = yba.bootstrap
 
   ssh_host_ip               = local.yba_ssh_host
   ssh_user                  = var.yba_admin_user
-  ssh_private_key_file_path = local.ssh_private_key_file
+  ssh_private_key           = tls_private_key.yba.private_key_openssh
   yba_license_file          = "${path.module}/../../yugabyte_anywhere.lic"
   application_settings_file = "${path.module}/../resources/yba-ctl.yml"
   yba_version               = var.yba_version
@@ -155,7 +138,6 @@ resource "yba_installer" "install" {
     aws_eip_association.yba,
     aws_security_group.main,
     aws_route_table_association.yba,
-    local_sensitive_file.ssh_private_key,
   ]
 }
 

--- a/acctest/azure/in-vars.tf
+++ b/acctest/azure/in-vars.tf
@@ -93,12 +93,6 @@ variable "yba_vm_size" {
   default     = "Standard_D4s_v3"
 }
 
-variable "ssh_private_key_file" {
-  description = "Path to the SSH private key used to install YBA; its .pub is added to the VM. ~ is expanded. Mirrors gcp/aws: an existing key is required because yba_installer validates the private-key path exists at plan time, so a key generated in the same apply cannot satisfy it. (Setting this to \"\" triggers in-apply key generation, which fails that plan-time check.)"
-  type        = string
-  default     = "~/.ssh/id_rsa"
-}
-
 variable "yba_admin_user" {
   description = "Admin (SSH) user created on the YBA VM. The installer connects as this user."
   type        = string

--- a/acctest/azure/providers.tf
+++ b/acctest/azure/providers.tf
@@ -37,10 +37,6 @@ terraform {
       source  = "hashicorp/tls"
       version = ">= 4.0"
     }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 2.0"
-    }
     yba = {
       source = "yugabyte/yba"
     }

--- a/acctest/azure/terraform.tfvars
+++ b/acctest/azure/terraform.tfvars
@@ -11,7 +11,7 @@ azure_region          = "westus2"
 
 # YBA version to install on the acceptance-test VM. Must be a valid downloadable
 # build (provider requires >= 2024.2.0.0). Update to the build you want to test.
-yba_version = "2025.2.3.1-b2"
+yba_version = "2.31.0.0-b164"
 
 vnet_cidr       = "10.0.0.0/16"
 yba_subnet_cidr = "10.0.1.0/24"

--- a/acctest/azure/yba.tf
+++ b/acctest/azure/yba.tf
@@ -7,37 +7,20 @@
 # `test_env` output so `make acctest` just consumes it. Tear down with the base.
 # Mirrors acctest/gcp.
 
-# SSH key for the installer. If var.ssh_private_key_file is set, reuse that
-# existing key (mirrors gcp/aws); otherwise generate a fresh ED25519 key and
-# write both halves into the working directory so the installer can read the
-# private half over the filesystem.
 locals {
-  generate_ssh_key     = var.ssh_private_key_file == ""
-  generated_key_path   = "${path.module}/.ssh-yba"
-  ssh_private_key_file = local.generate_ssh_key ? local.generated_key_path : pathexpand(var.ssh_private_key_file)
-  ssh_public_key_file  = "${local.ssh_private_key_file}.pub"
-  ssh_public_key       = local.generate_ssh_key ? tls_private_key.yba[0].public_key_openssh : file(local.ssh_public_key_file)
-  yba_ssh_host         = azurerm_public_ip.yba.ip_address
+  yba_ssh_host = azurerm_public_ip.yba.ip_address
 }
 
+# Dedicated SSH keypair for the standing YBA VM, generated once and kept in the
+# shared remote state (alongside random_password.customer). The public half goes
+# on the VM and the private half is fed to the installer inline via
+# ssh_private_key, so applies don't depend on (or drift against) any developer's
+# ~/.ssh keypair. Passing it inline (not as a file path) sidesteps the
+# installer's plan-time file-existence check, which a key generated in the same
+# apply can't satisfy.
 resource "tls_private_key" "yba" {
-  count     = local.generate_ssh_key ? 1 : 0
   algorithm = "RSA"
   rsa_bits  = 4096
-}
-
-resource "local_sensitive_file" "ssh_private_key" {
-  count           = local.generate_ssh_key ? 1 : 0
-  content         = tls_private_key.yba[0].private_key_openssh
-  filename        = local.generated_key_path
-  file_permission = "0600"
-}
-
-resource "local_file" "ssh_public_key" {
-  count           = local.generate_ssh_key ? 1 : 0
-  content         = tls_private_key.yba[0].public_key_openssh
-  filename        = "${local.generated_key_path}.pub"
-  file_permission = "0644"
 }
 
 # Static public IP for the YBA VM: a stable address for the installer (SSH) and
@@ -94,7 +77,7 @@ resource "azurerm_linux_virtual_machine" "yba" {
 
   admin_ssh_key {
     username   = var.yba_admin_user
-    public_key = local.ssh_public_key
+    public_key = tls_private_key.yba.public_key_openssh
   }
 
   os_disk {
@@ -130,16 +113,16 @@ resource "random_password" "customer" {
   override_special = "!#$%*-_"
 }
 
-# Install YugabyteDB Anywhere on the VM over SSH. The provider takes file paths
-# (validated to exist at plan time): the SSH key is the generated/provided
-# private half, the license is at the repo root, and yba-ctl.yml is in
-# acctest/resources. The installer connects as the VM admin user.
+# Install YugabyteDB Anywhere on the VM over SSH. The SSH key is the generated
+# keypair (passed inline); the license file is at the repo root and yba-ctl.yml
+# is in acctest/resources (both validated to exist at plan time). The installer
+# connects as the VM admin user.
 resource "yba_installer" "install" {
   provider = yba.bootstrap
 
   ssh_host_ip               = local.yba_ssh_host
   ssh_user                  = var.yba_admin_user
-  ssh_private_key_file_path = local.ssh_private_key_file
+  ssh_private_key           = tls_private_key.yba.private_key_openssh
   yba_license_file          = "${path.module}/../../yugabyte_anywhere.lic"
   application_settings_file = "${path.module}/../resources/yba-ctl.yml"
   yba_version               = var.yba_version
@@ -152,7 +135,6 @@ resource "yba_installer" "install" {
   depends_on = [
     azurerm_virtual_machine_data_disk_attachment.data,
     azurerm_subnet_network_security_group_association.yba,
-    local_sensitive_file.ssh_private_key,
   ]
 }
 

--- a/acctest/gcp/in-vars.tf
+++ b/acctest/gcp/in-vars.tf
@@ -71,12 +71,6 @@ variable "yba_machine_type" {
   default     = "n2-standard-4"
 }
 
-variable "ssh_private_key_file" {
-  description = "Path to the SSH private key used to install YBA; its .pub is added to the VM. ~ is expanded."
-  type        = string
-  default     = "~/.ssh/google_compute_engine"
-}
-
 variable "yba_username" {
   description = "Username (email) for the initial YBA superuser (customer). Published as the yba_username output."
   type        = string

--- a/acctest/gcp/providers.tf
+++ b/acctest/gcp/providers.tf
@@ -32,6 +32,10 @@ terraform {
       source  = "hashicorp/random"
       version = ">= 3.0"
     }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0"
+    }
   }
 }
 

--- a/acctest/gcp/terraform.tfvars
+++ b/acctest/gcp/terraform.tfvars
@@ -9,7 +9,7 @@ gcp_region     = "us-west1"
 
 # YBA version to install on the acceptance-test VM. Must be a valid downloadable
 # build (provider requires >= 2024.2.0.0). Update to the build you want to test.
-yba_version = "2025.2.3.1-b2"
+yba_version = "2.31.0.0-b164"
 
 yba_cidr  = "10.0.1.0/24"
 ybdb_cidr = "10.0.2.0/24"

--- a/acctest/gcp/yba.tf
+++ b/acctest/gcp/yba.tf
@@ -7,9 +7,19 @@
 # `make acctest` just consumes it. Tear down with the base.
 
 locals {
-  ssh_private_key_file = pathexpand(var.ssh_private_key_file)
-  ssh_public_key_file  = "${local.ssh_private_key_file}.pub"
-  yba_ssh_host         = google_compute_address.yba.address
+  yba_ssh_host = google_compute_address.yba.address
+}
+
+# Dedicated SSH keypair for the standing YBA VM, generated once and kept in the
+# shared remote state (alongside random_password.customer). The public half goes
+# on the VM and the private half is fed to the installer inline via
+# ssh_private_key, so applies don't depend on (or drift against) any developer's
+# ~/.ssh keypair. Passing it inline (not as a file path) sidesteps the
+# installer's plan-time file-existence check, which a key generated in the same
+# apply can't satisfy.
+resource "tls_private_key" "yba" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
 }
 
 # Resolve base_image (a family reference) to a concrete image. YBA's image-bundle
@@ -66,9 +76,9 @@ resource "google_compute_instance" "yba" {
     }
   }
 
-  # Standard gcloud keypair (matches the private key the installer uses).
+  # Public half of the generated keypair (the installer uses the private half).
   metadata = {
-    ssh-keys       = "yugabyte:${file(local.ssh_public_key_file)}"
+    ssh-keys       = "yugabyte:${tls_private_key.yba.public_key_openssh}"
     startup-script = file("${path.module}/../resources/gcp-bootscript.sh")
   }
 
@@ -88,15 +98,15 @@ resource "random_password" "customer" {
   override_special = "!#$%*-_"
 }
 
-# Install YugabyteDB Anywhere on the VM over SSH. The provider takes file
-# paths (validated to exist at plan time): the SSH key is the standard gcloud
-# keypair, the license is at the repo root, and yba-ctl.yml is in acctest/resources.
+# Install YugabyteDB Anywhere on the VM over SSH. The SSH key is the generated
+# keypair (passed inline); the license file is at the repo root and yba-ctl.yml
+# is in acctest/resources (both validated to exist at plan time).
 resource "yba_installer" "install" {
   provider = yba.bootstrap
 
   ssh_host_ip               = local.yba_ssh_host
   ssh_user                  = "yugabyte"
-  ssh_private_key_file_path = local.ssh_private_key_file
+  ssh_private_key           = tls_private_key.yba.private_key_openssh
   yba_license_file          = "${path.module}/../../yugabyte_anywhere.lic"
   application_settings_file = "${path.module}/../resources/yba-ctl.yml"
   yba_version               = var.yba_version

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,8 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1
-	github.com/yugabyte/platform-go-client v0.0.0-20260424070128-33f8cf839dd2
+	github.com/yugabyte/platform-go-client v0.0.0-20260612051126-0b0414ece83e
+	github.com/yugabyte/platform-go-client/v2 v2.0.0-20260612051126-0b0414ece83e
 	golang.org/x/crypto v0.53.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -195,8 +195,10 @@ github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAh
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
 github.com/xanzy/ssh-agent v0.3.3 h1:+/15pJfg/RsTxqYcX6fHqOXZwwMP+2VyYWJeWM2qQFM=
 github.com/xanzy/ssh-agent v0.3.3/go.mod h1:6dzNDKs0J9rVPHPhaGCukekBHKqfl+L3KghI1Bc68Uw=
-github.com/yugabyte/platform-go-client v0.0.0-20260424070128-33f8cf839dd2 h1:AG1wa5kUOXVcv5wWxtdRhEOdszHJcCRBOLypfz3igRI=
-github.com/yugabyte/platform-go-client v0.0.0-20260424070128-33f8cf839dd2/go.mod h1:8a2ONsBR0hUTroy6MRrMHaSmxD/peQNQOznL5EIw5no=
+github.com/yugabyte/platform-go-client v0.0.0-20260612051126-0b0414ece83e h1:Db0obZxni6XWfVlIQPdwPPb/bl9oq+u4siXw8fMrUq0=
+github.com/yugabyte/platform-go-client v0.0.0-20260612051126-0b0414ece83e/go.mod h1:8a2ONsBR0hUTroy6MRrMHaSmxD/peQNQOznL5EIw5no=
+github.com/yugabyte/platform-go-client/v2 v2.0.0-20260612051126-0b0414ece83e h1:kQ3NnCGsTeo4eMcV0xQg/4AW7PjQoOJBRvK6zVEzT4k=
+github.com/yugabyte/platform-go-client/v2 v2.0.0-20260612051126-0b0414ece83e/go.mod h1:d4Q0DnaoMs61ZufxsPrdd1P3WHV7qvwmh3Qi0huyFvk=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/yuin/goldmark v1.8.2 h1:kEGpgqJXdgbkhcOgBxkC0X0PmoPG1ZyoZ117rDVp4zE=
 github.com/yuin/goldmark v1.8.2/go.mod h1:ip/1k0VRfGynBgxOz0yCqHrbZXhcjxyuS66Brc7iBKg=

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -28,17 +28,19 @@ import (
 	"time"
 
 	client "github.com/yugabyte/platform-go-client"
+	clientv2 "github.com/yugabyte/platform-go-client/v2"
 
 	"github.com/yugabyte/terraform-provider-yba/internal/utils"
 )
 
 // APIClient struct to handle API calls
 type APIClient struct {
-	VanillaClient  *VanillaClient
-	YugawareClient *client.APIClient
-	APIKey         string
-	CustomerID     string
-	UserID         string // UUID of the logged-in user (API token holder)
+	VanillaClient    *VanillaClient
+	YugawareClient   *client.APIClient
+	YugawareClientV2 *clientv2.APIClient
+	APIKey           string
+	CustomerID       string
+	UserID           string // UUID of the logged-in user (API token holder)
 }
 
 // NewAPIClient creates a wrapper for public and non-public APIs
@@ -48,20 +50,28 @@ func NewAPIClient(enableHTTPS bool, host, apiKey string) (*APIClient, error) {
 	host = strings.TrimPrefix(host, "http://")
 	host = strings.TrimSuffix(host, "/")
 
-	// create swagger go client
+	// create swagger go client (v1)
 	cfg := client.NewConfiguration()
 	cfg.Host = host
+	// create v2 swagger go client (separate Go module, separate config)
+	cfgV2 := clientv2.NewConfiguration()
+	cfgV2.Host = host
 	if enableHTTPS {
-		cfg.Scheme = "https"
 		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		cfg.Scheme = "https"
 		cfg.HTTPClient = &http.Client{Transport: tr}
+		cfgV2.Scheme = "https"
+		cfgV2.HTTPClient = &http.Client{Transport: tr}
 	} else {
 		cfg.Scheme = "http"
+		cfgV2.Scheme = "http"
 	}
 	if apiKey != "" {
 		cfg.DefaultHeader = map[string]string{"X-AUTH-YW-API-TOKEN": apiKey}
+		cfgV2.DefaultHeader = map[string]string{"X-AUTH-YW-API-TOKEN": apiKey}
 	}
 	ywc := client.NewAPIClient(cfg)
+	ywcV2 := clientv2.NewAPIClient(cfgV2)
 
 	// create vanilla client for non-public APIs
 	vc := &VanillaClient{
@@ -72,9 +82,10 @@ func NewAPIClient(enableHTTPS bool, host, apiKey string) (*APIClient, error) {
 
 	// create wrapper client
 	c := &APIClient{
-		VanillaClient:  vc,
-		YugawareClient: ywc,
-		APIKey:         apiKey,
+		VanillaClient:    vc,
+		YugawareClient:   ywc,
+		YugawareClientV2: ywcV2,
+		APIKey:           apiKey,
 	}
 
 	// authenticate if api token is provided

--- a/internal/utils/conflict_test.go
+++ b/internal/utils/conflict_test.go
@@ -1,0 +1,125 @@
+// Licensed to YugabyteDB, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Mozilla License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://mozilla.org/MPL/2.0/.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package utils
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	client "github.com/yugabyte/platform-go-client"
+)
+
+// TestIsUniverseTaskConflictResponse covers the cheap response-only paths of
+// IsUniverseTaskConflict that do not require a real *GenericOpenAPIError
+// (the generated client error type has unexported fields and cannot be
+// constructed from outside the client package).
+func TestIsUniverseTaskConflictResponse(t *testing.T) {
+	cases := []struct {
+		name string
+		resp *http.Response
+		err  error
+		want bool
+	}{
+		{"nil response", nil, errors.New("boom"), false},
+		{
+			"non-409 response",
+			&http.Response{StatusCode: http.StatusInternalServerError},
+			errors.New("boom"),
+			false,
+		},
+		{
+			"409 plain error has no body",
+			&http.Response{StatusCode: http.StatusConflict},
+			errors.New("409 Conflict"),
+			false,
+		},
+		{"409 nil error", &http.Response{StatusCode: http.StatusConflict}, nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsUniverseTaskConflict(tc.resp, tc.err); got != tc.want {
+				t.Errorf("IsUniverseTaskConflict = %v want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsUniverseTaskConflictRealClient drives the helper end-to-end through
+// the generated client so that body extraction is exercised against the real
+// *GenericOpenAPIError type that appears at runtime. Each case stands up a
+// throwaway HTTP server that returns a YBA-shaped 409 response and verifies
+// the helper either matches or rejects it appropriately.
+func TestIsUniverseTaskConflictRealClient(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "cannot be queued",
+			body: `{"error":"Task ConfigureExportTelemetryConfig cannot be queued on existing task ConfigureExportTelemetryConfig"}`,
+			want: true,
+		},
+		{
+			name: "locked state",
+			body: `{"error":"Cannot run Backup task since the universe U is currently in a locked state."}`,
+			want: true,
+		},
+		{
+			name: "unrelated 409",
+			body: `{"error":"Some other 4xx that is not a universe task conflict"}`,
+			want: false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := httptest.NewServer(
+				http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusConflict)
+					_, _ = w.Write([]byte(tc.body))
+				}),
+			)
+			defer srv.Close()
+
+			cfg := client.NewConfiguration()
+			cfg.Scheme = "http"
+			cfg.Host = srv.Listener.Addr().String()
+			c := client.NewAPIClient(cfg)
+
+			_, resp, err := c.SessionManagementAPI.AppVersion(context.Background()).Execute()
+			if err == nil {
+				t.Fatalf("expected an error from 409 stub server")
+			}
+			if resp == nil || resp.StatusCode != http.StatusConflict {
+				t.Fatalf("expected HTTP 409, got resp=%v", resp)
+			}
+			if got := IsUniverseTaskConflict(resp, err); got != tc.want {
+				t.Errorf("IsUniverseTaskConflict = %v want %v\nbody=%s", got, tc.want, tc.body)
+			}
+			// Also verify wrapped errors still match (DispatchAndWait wraps
+			// errors via fmt.Errorf("...: %w", err) before returning).
+			wrapped := fmt.Errorf("dispatch failed: %w", err)
+			if got := IsUniverseTaskConflict(resp, wrapped); got != tc.want {
+				t.Errorf("IsUniverseTaskConflict (wrapped) = %v want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	client "github.com/yugabyte/platform-go-client"
+	clientv2 "github.com/yugabyte/platform-go-client/v2"
 )
 
 // YbaStructuredError is a structure mimicking YBPError, with error being an interface{}
@@ -749,20 +750,30 @@ func CheckHTTPError(resp *http.Response, operation string) error {
 //     locked state."
 //     (universe.updateInProgress is true while a task holds the universe lock)
 //
-// The generated platform-go-client returns errors as *GenericOpenAPIError (pointer),
-// so we use errors.As rather than a direct type assertion. err.Error() only returns
-// the HTTP status line ("409 Conflict"), not the body, so we always inspect Body().
+// err.Error() on either client only returns the HTTP status line ("409 Conflict"),
+// not the body, so we always inspect the body via OpenAPIErrorBody.
 func IsUniverseTaskConflict(response *http.Response, err error) bool {
 	if response == nil || response.StatusCode != http.StatusConflict {
 		return false
 	}
-	var oErr *client.GenericOpenAPIError
-	if errors.As(err, &oErr) {
-		body := string(oErr.Body())
-		return strings.Contains(body, "cannot be queued") ||
-			strings.Contains(body, "currently in a locked state")
+	body := OpenAPIErrorBody(err)
+	return strings.Contains(body, "cannot be queued") ||
+		strings.Contains(body, "currently in a locked state")
+}
+
+// OpenAPIErrorBody walks the error chain and returns the response body of the
+// first *GenericOpenAPIError from either generated client (platform-go-client
+// or platform-go-client/v2). Returns "" if no such error is present.
+func OpenAPIErrorBody(err error) string {
+	var v1Err *client.GenericOpenAPIError
+	if errors.As(err, &v1Err) {
+		return string(v1Err.Body())
 	}
-	return false
+	var v2Err *clientv2.GenericOpenAPIError
+	if errors.As(err, &v2Err) {
+		return string(v2Err.Body())
+	}
+	return ""
 }
 
 // RetryOnUniverseTaskConflict calls fn repeatedly whenever YBA returns a 409 Conflict


### PR DESCRIPTION
### Description
Updates YBA version
Changes SSH key for acc test YBA to not leak into state
Bumps the v2 client version

All the changes are not required for https://github.com/yugabyte/terraform-provider-yba/pull/314 and separate out the non telemetry related changes that are needed before that can be merged.

### Testing

Was deployed using make -C accteset destroy-{cloud} and then apply-{cloud} and secrets pushed to github. 