### PR TITLE
Support YBA install with a mounted data disk + OS-image-upgrade long test

### DIFF
--- a/.github/workflows/acctest-long.yml
+++ b/.github/workflows/acctest-long.yml
@@ -42,10 +42,8 @@ jobs:
         env:
           ACCTEST_ENV: ${{ secrets.ACCTEST_ENV }}
 
-      # TestAccLong_YBA_GCP_OSImageUpgrade installs its own throwaway YBA, which
-      # needs the YBA license (the universe long tests reuse the standing YBA and
-      # don't). Reuse the same YBA_LICENSE secret the fixture is installed with;
-      # if it's ever unset the test skips rather than fails.
+      # TestAccLong_YBA_GCP_OSImageUpgrade installs its own throwaway YBA and
+      # needs the license file; unset secret means the test skips, not fails.
       - name: Load YBA license
         run: |
           if [ -n "$YBA_LICENSE" ]; then

--- a/.github/workflows/acctest-long.yml
+++ b/.github/workflows/acctest-long.yml
@@ -42,6 +42,18 @@ jobs:
         env:
           ACCTEST_ENV: ${{ secrets.ACCTEST_ENV }}
 
+      # TestAccLong_YBA_GCP_OSImageUpgrade installs its own throwaway YBA, which
+      # needs the YBA license (the universe long tests reuse the standing YBA and
+      # don't). Reuse the same YBA_LICENSE secret the fixture is installed with;
+      # if it's ever unset the test skips rather than fails.
+      - name: Load YBA license
+        run: |
+          if [ -n "$YBA_LICENSE" ]; then
+            printf '%s' "$YBA_LICENSE" > yugabyte_anywhere.lic
+          fi
+        env:
+          YBA_LICENSE: ${{ secrets.YBA_LICENSE }}
+
       - name: Install gotestsum
         run: make gotestsum-install
 

--- a/acctest/gcp/out-vars.tf
+++ b/acctest/gcp/out-vars.tf
@@ -20,6 +20,7 @@ locals {
     TF_VAR_GCP_REGION='${var.gcp_region}'
     TF_VAR_GCP_SUBNETWORK='${google_compute_subnetwork.ybdb.name}'
     TF_VAR_GCP_IMAGE='${data.google_compute_image.ybdb.self_link}'
+    TF_VAR_GCP_YBA_VERSION='${var.yba_version}'
     TF_VAR_GCS_BACKUP_LOCATION='gs://${google_storage_bucket.backups.name}'
     TF_VAR_GCP_YBA_HOST='${google_compute_address.yba.address}'
     TF_VAR_GCP_YBA_API_KEY='${yba_customer_resource.customer.api_token}'

--- a/docs/resources/installer.md
+++ b/docs/resources/installer.md
@@ -10,7 +10,7 @@ description: |-
 
 Manages the installation of YugabyteDB Anywhere on an existing virtual machine using YBA Installer.
 
-~> **Note:** When `/opt/yugabyte/data` is already populated (typically because it lives on a separately managed persistent disk that survives the host VM), the resource installs with `--without-data` and starts services in place rather than reinitialising storage. Destroy runs `yba-ctl clean` only and leaves `/opt/yugabyte/data` intact; wiping the data directory is the operator's responsibility.
+~> **Note:** When `/opt/yugabyte/data` is already populated (typically because it lives on a separately managed persistent disk that survives the host VM), the resource installs with `--without-data` and starts services in place rather than reinitialising storage. Destroy runs `yba-ctl clean` only and leaves `/opt/yugabyte/data` intact; wiping the data directory is the operator's responsibility. Consequently, destroying and recreating this resource on the **same** host preserves the existing data: the recreate detects the populated data directory and starts in place instead of performing a clean install. To force a fresh install, wipe `/opt/yugabyte/data` on the host between destroy and apply.
 
 ## Supported Versions
 

--- a/docs/resources/installer.md
+++ b/docs/resources/installer.md
@@ -10,6 +10,17 @@ description: |-
 
 Manages the installation of YugabyteDB Anywhere on an existing virtual machine using YBA Installer.
 
+~> **Note:** When `/opt/yugabyte/data` is already populated (typically because it lives on a separately managed persistent disk that survives the host VM), the resource installs with `--without-data` and starts services in place rather than reinitialising storage. Destroy runs `yba-ctl clean` only and leaves `/opt/yugabyte/data` intact; wiping the data directory is the operator's responsibility.
+
+## Supported Versions
+
+Both GA releases and pre-release CI builds are supported.
+
+| Version format        | Example           |
+| --------------------- | ----------------- |
+| GA release (`20YY.x`) | `2025.2.2.2-b11`  |
+| Pre-release (`2.xx`)  | `2.31.0.0-b14`    |
+
 ## Example Usage
 
 ```terraform

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -646,20 +646,14 @@ func resourceYBAInstallerDelete(
 	sshClient, err := connectSSHForDelete(ctx, user, hostIPForSSH, pk)
 	if err != nil {
 		if errors.Is(err, errSSHHostUnreachable) {
-			// After retrying within the budget we still couldn't open a TCP
-			// connection, so the host is effectively gone (e.g. caller wired
-			// lifecycle.replace_triggered_by to the cloud VM, so the VM was
-			// destroyed first). There's nothing to clean up remotely and an
-			// empty host is the desired terminal state.
+			// Host never answered TCP within the retry budget: it's already gone
+			// (e.g. replace_triggered_by destroyed the VM first) — nothing to clean up.
 			tflog.Warn(ctx, fmt.Sprintf(
 				"yba_installer: host %s unreachable after retries, treating as "+
 					"already destroyed: %v", hostIPForSSH, err))
 			d.SetId("")
 			return diags
 		}
-		// The host answered (or the key is malformed): this is a real error
-		// the operator must fix before destroy can clean up the still-running
-		// YBA install. Fail loudly rather than silently dropping the resource.
 		return diag.FromErr(err)
 	}
 	defer func() { _ = sshClient.Close() }()
@@ -735,27 +729,17 @@ func getAddLicenseCommand(version, folder string) string {
 		ybaCtlSudo(version), folder)
 }
 
-// getInstallCommands returns the ordered list of shell commands that
-// stage and run a fresh YBA install. The final command auto-detects
-// whether /opt/yugabyte/data already holds a previous YBA install (e.g.
-// a separately managed persistent data disk that survived an OS-image
-// upgrade) and picks the correct yba-ctl invocation. It probes for the
-// data/yb-platform directory that yba-ctl creates, rather than mere
-// directory non-emptiness, so a freshly formatted disk's mkfs artifacts
-// (notably ext4's lost+found) don't masquerade as existing data. When
-// YBA data is present the install runs with --without-data and is
-// followed by `yba-ctl start`; otherwise the original `install -f` path
-// runs untouched, which keeps callers that don't use a separate data
-// disk behaving exactly as before.
+// getInstallCommands stages and runs a fresh YBA install. The final command
+// branches on /opt/yugabyte/data/yb-platform — not mere dir non-emptiness,
+// since a fresh mkfs leaves lost+found — so a surviving data disk gets
+// `install --without-data` + `start` instead of reinitialising storage.
 func getInstallCommands(
 	version, os, arch string,
 	config bool, skipPreflightCheckList *[]string) []string {
 	folder, cmds := getBundleDownloadCommands(version, os, arch)
 	cmds = append(cmds, getAddLicenseCommand(version, folder))
 	if config {
-		// The yba_installer_full tarball doesn't create /opt/yba-ctl
-		// before `install` runs; mkdir -p keeps the staged mv safe on
-		// hosts where the directory doesn't yet exist.
+		// /opt/yba-ctl doesn't exist until `install` runs; mkdir so the mv lands.
 		cmds = append(cmds,
 			"sudo mkdir -p /opt/yba-ctl",
 			"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml")
@@ -781,12 +765,9 @@ func getInstallCommands(
 
 func getReconfigureCommands(version, os, arch string) []string {
 	folder, downloadCmds := getBundleDownloadCommands(version, os, arch)
-	// yba-ctl uses a relative glob to find perf_advisor-*.tar.gz inside the
-	// extracted installer bundle, so it must run with that directory as CWD.
-	// A reconfigure-only apply doesn't otherwise download the bundle, and the
-	// extracted dir may be absent (an imported resource, a cleaned/ephemeral
-	// home, or a different SSH user than the original install), so fetch it on
-	// demand when it's missing rather than failing the whole apply on `cd`.
+	// yba-ctl reconfigure globs perf_advisor-*.tar.gz relative to CWD, so it must
+	// run from the extracted bundle dir. A reconfigure-only apply may not have it
+	// (import, cleaned home, different SSH user), so fetch on demand.
 	return []string{
 		"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml",
 		fmt.Sprintf("[ -d ~/%s ] || ( %s )", folder, strings.Join(downloadCmds, " && ")),
@@ -808,12 +789,8 @@ func getUpgradeCommands(version, os, arch string, skipPreflightCheckList *[]stri
 	return updateCommands
 }
 
-// getDeleteCommands returns the shell commands run during resource
-// destroy. yba-ctl clean (without --all) stops services and removes
-// /opt/yba-ctl/ but deliberately preserves /opt/yugabyte/data; that
-// matters when the data directory lives on a separately managed
-// persistent disk that must outlive the YBA host. Explicit data wipe
-// is the operator's responsibility, not this resource's.
+// getDeleteCommands runs `clean` without --all: /opt/yugabyte/data must outlive
+// the host when it lives on a separate data disk; wiping it is the operator's job.
 func getDeleteCommands(version string) []string {
 	return []string{
 		fmt.Sprintf("%s /opt/yba-ctl/yba-ctl clean", ybaCtlSudo(version)),

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -196,7 +196,14 @@ func installerInputProvided(d inputReader, spec installerFileSpec) bool {
 func ResourceYBAInstaller() *schema.Resource {
 	return &schema.Resource{
 		Description: "Manages the installation of YugabyteDB Anywhere on an existing virtual" +
-			" machine using YBA Installer. ",
+			" machine using YBA Installer.\n\n" +
+			"~> **Note:** When `/opt/yugabyte/data` is already populated " +
+			"(typically because it lives on a separately managed " +
+			"persistent disk that survives the host VM), the resource " +
+			"installs with `--without-data` and starts services in place " +
+			"rather than reinitialising storage. Destroy runs `yba-ctl " +
+			"clean` only and leaves `/opt/yugabyte/data` intact; wiping " +
+			"the data directory is the operator's responsibility.",
 
 		CreateContext: resourceYBAInstallerCreate,
 		ReadContext:   resourceYBAInstallerRead,
@@ -633,7 +640,19 @@ func resourceYBAInstallerDelete(
 
 	sshClient, err := newSSHClient(user, hostIPForSSH, pk)
 	if err != nil {
-		return diag.FromErr(err)
+		// The host may already be gone (e.g. caller wired
+		// lifecycle.replace_triggered_by to the cloud VM, so the VM
+		// was destroyed first; or the host is simply unreachable
+		// during the destroy half of a replace cycle). In every such
+		// case there's nothing to clean up remotely, and an empty
+		// host is the desired terminal state. Surface the reason and
+		// move on rather than blocking destroy on a side effect that
+		// can never succeed.
+		tflog.Warn(ctx, fmt.Sprintf(
+			"yba_installer: skipping remote cleanup, SSH to %s failed: %v",
+			hostIPForSSH, err))
+		d.SetId("")
+		return diags
 	}
 	defer func() { _ = sshClient.Close() }()
 
@@ -708,21 +727,46 @@ func getAddLicenseCommand(version, folder string) string {
 		ybaCtlSudo(version), folder)
 }
 
+// getInstallCommands returns the ordered list of shell commands that
+// stage and run a fresh YBA install. The final command auto-detects
+// whether /opt/yugabyte/data is already populated (e.g. a separately
+// managed persistent data disk that survived an OS-image upgrade) and
+// picks the correct yba-ctl invocation. When the data dir is
+// non-empty the install runs with --without-data and is followed by
+// `yba-ctl start`; otherwise the original `install -f` path runs
+// untouched, which keeps callers that don't use a separate data disk
+// behaving exactly as before.
 func getInstallCommands(
 	version, os, arch string,
 	config bool, skipPreflightCheckList *[]string) []string {
-	folder, installationCommands := getBundleDownloadCommands(version, os, arch)
-	installationCommands = append(installationCommands, getAddLicenseCommand(version, folder))
+	folder, cmds := getBundleDownloadCommands(version, os, arch)
+	cmds = append(cmds, getAddLicenseCommand(version, folder))
 	if config {
-		installationCommands = append(installationCommands,
+		// The yba_installer_full tarball doesn't create /opt/yba-ctl
+		// before `install` runs; mkdir -p keeps the staged mv safe on
+		// hosts where the directory doesn't yet exist.
+		cmds = append(cmds,
+			"sudo mkdir -p /opt/yba-ctl",
 			"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml")
 	}
-	s := fmt.Sprintf("%s ./%s/yba-ctl install -f", ybaCtlSudo(version), folder)
+	installPrefix := fmt.Sprintf("%s ./%s/yba-ctl install -f", ybaCtlSudo(version), folder)
+	ybactl := fmt.Sprintf("%s /opt/yba-ctl/yba-ctl", ybaCtlSudo(version))
+
+	skipSuffix := ""
 	if skipPreflightCheckList != nil && len(*skipPreflightCheckList) != 0 {
-		s = fmt.Sprintf("%s -s %s", s, strings.Join(*skipPreflightCheckList, ","))
+		skipSuffix = fmt.Sprintf(" -s %s", strings.Join(*skipPreflightCheckList, ","))
 	}
-	installationCommands = append(installationCommands, s)
-	return installationCommands
+
+	cmds = append(cmds, fmt.Sprintf(
+		`if [ -d /opt/yugabyte/data ] && `+
+			`[ -n "$(sudo ls -A /opt/yugabyte/data 2>/dev/null)" ]; then `+
+			`%s --without-data%s && %s start; `+
+			`else %s%s; `+
+			`fi`,
+		installPrefix, skipSuffix, ybactl,
+		installPrefix, skipSuffix,
+	))
+	return cmds
 }
 
 func getReconfigureCommands(version string) []string {
@@ -731,7 +775,11 @@ func getReconfigureCommands(version string) []string {
 	// extracted installer bundle, so it must run with that directory as CWD.
 	return []string{
 		"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml",
-		fmt.Sprintf("cd ~/%s && %s /opt/yba-ctl/yba-ctl reconfigure -f", folder, ybaCtlSudo(version)),
+		fmt.Sprintf(
+			"cd ~/%s && %s /opt/yba-ctl/yba-ctl reconfigure -f",
+			folder,
+			ybaCtlSudo(version),
+		),
 	}
 }
 
@@ -745,12 +793,15 @@ func getUpgradeCommands(version, os, arch string, skipPreflightCheckList *[]stri
 	return updateCommands
 }
 
+// getDeleteCommands returns the shell commands run during resource
+// destroy. yba-ctl clean (without --all) stops services and removes
+// /opt/yba-ctl/ but deliberately preserves /opt/yugabyte/data; that
+// matters when the data directory lives on a separately managed
+// persistent disk that must outlive the YBA host. Explicit data wipe
+// is the operator's responsibility, not this resource's.
 func getDeleteCommands(version string) []string {
-	var deleteCommands = []string{
+	return []string{
 		fmt.Sprintf("%s /opt/yba-ctl/yba-ctl clean", ybaCtlSudo(version)),
+		"sudo rm -f /tmp/server.crt /tmp/server.key /tmp/license.lic /tmp/settings.yml",
 	}
-	deleteCommands = append(deleteCommands, "sudo rm -rf /opt/yugabyte")
-	deleteCommands = append(deleteCommands,
-		"sudo rm /tmp/server.crt /tmp/server.key /tmp/license.lic /tmp/settings.yml")
-	return deleteCommands
 }

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -726,10 +726,13 @@ func getInstallCommands(
 }
 
 func getReconfigureCommands(version string) []string {
-	var reconfigureCommands = []string{"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml"}
-	reconfigureCommands = append(reconfigureCommands,
-		fmt.Sprintf("%s /opt/yba-ctl/yba-ctl reconfigure -f", ybaCtlSudo(version)))
-	return reconfigureCommands
+	folder := fmt.Sprintf("yba_installer_full-%s", version)
+	// yba-ctl uses a relative glob to find perf_advisor-*.tar.gz inside the
+	// extracted installer bundle, so it must run with that directory as CWD.
+	return []string{
+		"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml",
+		fmt.Sprintf("cd ~/%s && %s /opt/yba-ctl/yba-ctl reconfigure -f", folder, ybaCtlSudo(version)),
+	}
 }
 
 func getUpgradeCommands(version, os, arch string, skipPreflightCheckList *[]string) []string {

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -203,7 +203,12 @@ func ResourceYBAInstaller() *schema.Resource {
 			"installs with `--without-data` and starts services in place " +
 			"rather than reinitialising storage. Destroy runs `yba-ctl " +
 			"clean` only and leaves `/opt/yugabyte/data` intact; wiping " +
-			"the data directory is the operator's responsibility.",
+			"the data directory is the operator's responsibility. " +
+			"Consequently, destroying and recreating this resource on the " +
+			"**same** host preserves the existing data: the recreate detects " +
+			"the populated data directory and starts in place instead of " +
+			"performing a clean install. To force a fresh install, wipe " +
+			"`/opt/yugabyte/data` on the host between destroy and apply.",
 
 		CreateContext: resourceYBAInstallerCreate,
 		ReadContext:   resourceYBAInstallerRead,
@@ -603,7 +608,7 @@ func resourceYBAInstallerUpdate(
 				"reconfiguration")
 			return diag.FromErr(err)
 		}
-		commands = append(commands, getReconfigureCommands(oldVersion)...)
+		commands = append(commands, getReconfigureCommands(oldVersion, hostOS, hostArch)...)
 	}
 
 	if d.HasChange("yba_version") {
@@ -638,21 +643,24 @@ func resourceYBAInstallerDelete(
 		return diag.FromErr(err)
 	}
 
-	sshClient, err := newSSHClient(user, hostIPForSSH, pk)
+	sshClient, err := connectSSHForDelete(ctx, user, hostIPForSSH, pk)
 	if err != nil {
-		// The host may already be gone (e.g. caller wired
-		// lifecycle.replace_triggered_by to the cloud VM, so the VM
-		// was destroyed first; or the host is simply unreachable
-		// during the destroy half of a replace cycle). In every such
-		// case there's nothing to clean up remotely, and an empty
-		// host is the desired terminal state. Surface the reason and
-		// move on rather than blocking destroy on a side effect that
-		// can never succeed.
-		tflog.Warn(ctx, fmt.Sprintf(
-			"yba_installer: skipping remote cleanup, SSH to %s failed: %v",
-			hostIPForSSH, err))
-		d.SetId("")
-		return diags
+		if errors.Is(err, errSSHHostUnreachable) {
+			// After retrying within the budget we still couldn't open a TCP
+			// connection, so the host is effectively gone (e.g. caller wired
+			// lifecycle.replace_triggered_by to the cloud VM, so the VM was
+			// destroyed first). There's nothing to clean up remotely and an
+			// empty host is the desired terminal state.
+			tflog.Warn(ctx, fmt.Sprintf(
+				"yba_installer: host %s unreachable after retries, treating as "+
+					"already destroyed: %v", hostIPForSSH, err))
+			d.SetId("")
+			return diags
+		}
+		// The host answered (or the key is malformed): this is a real error
+		// the operator must fix before destroy can clean up the still-running
+		// YBA install. Fail loudly rather than silently dropping the resource.
+		return diag.FromErr(err)
 	}
 	defer func() { _ = sshClient.Close() }()
 
@@ -729,13 +737,16 @@ func getAddLicenseCommand(version, folder string) string {
 
 // getInstallCommands returns the ordered list of shell commands that
 // stage and run a fresh YBA install. The final command auto-detects
-// whether /opt/yugabyte/data is already populated (e.g. a separately
-// managed persistent data disk that survived an OS-image upgrade) and
-// picks the correct yba-ctl invocation. When the data dir is
-// non-empty the install runs with --without-data and is followed by
-// `yba-ctl start`; otherwise the original `install -f` path runs
-// untouched, which keeps callers that don't use a separate data disk
-// behaving exactly as before.
+// whether /opt/yugabyte/data already holds a previous YBA install (e.g.
+// a separately managed persistent data disk that survived an OS-image
+// upgrade) and picks the correct yba-ctl invocation. It probes for the
+// data/yb-platform directory that yba-ctl creates, rather than mere
+// directory non-emptiness, so a freshly formatted disk's mkfs artifacts
+// (notably ext4's lost+found) don't masquerade as existing data. When
+// YBA data is present the install runs with --without-data and is
+// followed by `yba-ctl start`; otherwise the original `install -f` path
+// runs untouched, which keeps callers that don't use a separate data
+// disk behaving exactly as before.
 func getInstallCommands(
 	version, os, arch string,
 	config bool, skipPreflightCheckList *[]string) []string {
@@ -758,8 +769,7 @@ func getInstallCommands(
 	}
 
 	cmds = append(cmds, fmt.Sprintf(
-		`if [ -d /opt/yugabyte/data ] && `+
-			`[ -n "$(sudo ls -A /opt/yugabyte/data 2>/dev/null)" ]; then `+
+		`if sudo test -d /opt/yugabyte/data/yb-platform; then `+
 			`%s --without-data%s && %s start; `+
 			`else %s%s; `+
 			`fi`,
@@ -769,12 +779,17 @@ func getInstallCommands(
 	return cmds
 }
 
-func getReconfigureCommands(version string) []string {
-	folder := fmt.Sprintf("yba_installer_full-%s", version)
+func getReconfigureCommands(version, os, arch string) []string {
+	folder, downloadCmds := getBundleDownloadCommands(version, os, arch)
 	// yba-ctl uses a relative glob to find perf_advisor-*.tar.gz inside the
 	// extracted installer bundle, so it must run with that directory as CWD.
+	// A reconfigure-only apply doesn't otherwise download the bundle, and the
+	// extracted dir may be absent (an imported resource, a cleaned/ephemeral
+	// home, or a different SSH user than the original install), so fetch it on
+	// demand when it's missing rather than failing the whole apply on `cd`.
 	return []string{
 		"sudo mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml",
+		fmt.Sprintf("[ -d ~/%s ] || ( %s )", folder, strings.Join(downloadCmds, " && ")),
 		fmt.Sprintf(
 			"cd ~/%s && %s /opt/yba-ctl/yba-ctl reconfigure -f",
 			folder,

--- a/internal/installation/resource_yba_installer_os_upgrade_test.go
+++ b/internal/installation/resource_yba_installer_os_upgrade_test.go
@@ -459,17 +459,13 @@ func repoPath(parts ...string) string {
 var gcpNameInvalid = regexp.MustCompile(`[^a-z0-9-]`)
 
 // gcpSafeName coerces an acctest random name into a valid GCP resource name:
-// lowercase, only [a-z0-9-], starts with a letter, ends with a letter/digit,
-// and short enough to leave room for the "-data"/"-provider" suffixes this test
-// appends (GCP caps names at 63 chars).
+// lowercase, only [a-z0-9-], starting with a letter and ending with a letter
+// or digit.
 func gcpSafeName(s string) string {
 	s = gcpNameInvalid.ReplaceAllString(strings.ToLower(s), "-")
 	s = strings.Trim(s, "-")
 	if s == "" || s[0] < 'a' || s[0] > 'z' {
 		s = "yba-" + s
-	}
-	if len(s) > 45 {
-		s = strings.TrimRight(s[:45], "-")
 	}
 	return s
 }

--- a/internal/installation/resource_yba_installer_os_upgrade_test.go
+++ b/internal/installation/resource_yba_installer_os_upgrade_test.go
@@ -33,47 +33,21 @@ import (
 	"github.com/yugabyte/terraform-provider-yba/internal/api"
 )
 
-// TestAccLong_YBA_GCP_OSImageUpgrade exercises the data-disk rehydration flow
-// end-to-end on a throwaway YBA stand it deploys itself (NOT the shared standing
-// fixture YBA, which other tests depend on and must not be reimaged).
-//
-// OLD and NEW are resolved automatically as the two most recent AlmaLinux 9
-// images (NEW = the family head, OLD = the next most recent), so nothing pins a
-// specific image. Both are AlmaLinux 9 on purpose: YBA installs the same way on
-// each, whereas the alma8 family ships an older Python that YBA's preflight
-// rejects.
-//
-// Flow:
-//  1. Stand up a fresh GCP VM (boot image = OLD) with a separate persistent data
-//     disk mounted at /opt/yugabyte/data, install YBA over SSH via yba_installer,
-//     register the first customer, and create a yba_gcp_provider through that YBA.
-//  2. Flip the VM boot image OLD -> NEW. GCP can't reimage in place, so the VM is
-//     destroyed and recreated; the data disk is NOT recreated and re-attaches to
-//     the new VM, the startup script re-mounts /opt/yugabyte/data, and the
-//     installer (wired with replace_triggered_by on the VM) re-runs. Because the
-//     data dir is now populated it installs with --without-data, rehydrating YBA
-//     from the surviving disk.
-//
-// Assertions:
-//   - The VM was actually reimaged (its server-assigned instance_id changed).
-//   - The yba_gcp_provider was NOT recreated (its UUID is unchanged) AND it still
-//     exists in the rehydrated YBA — i.e. no YBA state was lost across the host
-//     OS-image upgrade.
-//
-// This is a long test (~30 min: two YBA installs on real GCP). It reuses the
-// standing fixture's network/project/credentials but stands up its OWN VM, data
-// disk, YBA install, and cloud provider — none of the standing fixture's
-// resources are modified — and tears them all down at the end (resource.Test
-// runs destroy even on failure). It needs only the standing fixture env,
-// TF_VAR_GCP_YBA_VERSION, and the YBA license at the repo root; any missing ->
-// the test skips, not fails.
+// TestAccLong_YBA_GCP_OSImageUpgrade proves YBA survives a host reimage. It
+// stands up its own throwaway YBA on a fresh GCP VM (never the shared standing
+// fixture, which must not be reimaged) with /opt/yugabyte/data on a separate
+// persistent disk, creates a yba_gcp_provider, then flips the boot image so
+// the VM is destroyed and recreated. The reinstall must rehydrate from the
+// surviving data disk: instance_id changes, provider UUID doesn't. Both images
+// are AlmaLinux 9 — alma8's older Python fails YBA preflight. ~30 min (two
+// real YBA installs); missing TF_VAR_GCP_YBA_VERSION or repo-root license
+// skips the test rather than failing it.
 func TestAccLong_YBA_GCP_OSImageUpgrade(t *testing.T) {
 	ybaVersion := os.Getenv("TF_VAR_GCP_YBA_VERSION")
 	licensePath := repoPath("yugabyte_anywhere.lic")
 	settingsPath := repoPath("acctest", "resources", "yba-ctl.yml")
 	bootScriptPath := repoPath("acctest", "resources", "gcp-bootscript.sh")
 
-	// Captured from Terraform state between the two steps.
 	var providerUUIDBefore, providerUUIDAfter string
 	var instanceIDBefore, instanceIDAfter string
 
@@ -90,8 +64,6 @@ func TestAccLong_YBA_GCP_OSImageUpgrade(t *testing.T) {
 					licensePath)
 			}
 		},
-		// yba comes from the in-process factory; the infra providers are pulled
-		// from the registry for the duration of the test.
 		ProviderFactories: acctest.ProviderFactories,
 		ExternalProviders: map[string]resource.ExternalProvider{
 			"google": {Source: "hashicorp/google", VersionConstraint: ">= 5.0"},
@@ -161,9 +133,8 @@ func checkOSUpgradePreservedProvider(t *testing.T,
 	}
 }
 
-// checkProviderStillOnYBA queries the rehydrated YBA directly (using the host and
-// API token from state, not the shared fixture YBA) and confirms the provider
-// created before the upgrade is still present — the direct proof that
+// checkProviderStillOnYBA asks the rehydrated YBA (host/token from state, not
+// the shared fixture YBA) for the pre-upgrade provider — direct proof that
 // /opt/yugabyte/data survived.
 func checkProviderStillOnYBA(t *testing.T, providerUUID *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
@@ -198,8 +169,8 @@ func checkProviderStillOnYBA(t *testing.T, providerUUID *string) resource.TestCh
 	}
 }
 
-// captureAttr records a resource attribute from state into out for cross-step
-// comparison. The synthetic attribute name "id" reads Primary.ID.
+// captureAttr saves a state attribute into out for cross-step comparison;
+// attr "id" reads Primary.ID, not a real attribute.
 func captureAttr(resourceName, attr string, out *string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
@@ -249,10 +220,8 @@ provider "google" {
   credentials = var.GCP_CREDENTIALS
 }
 
-# Resolve the two most recent AlmaLinux 9 images so the upgrade is always between
-# real, current releases and nobody has to pin image names. new = the family
-# head (newest); old = the most recent almalinux-9 whose name differs from new,
-# i.e. the second newest.
+# Two most recent AlmaLinux 9 images, so nothing pins image names: new = family
+# head, old = newest almalinux-9 whose name differs from new (second newest).
 data "google_compute_image" "new" {
   project     = "almalinux-cloud"
   family      = "almalinux-9"
@@ -281,9 +250,8 @@ provider "yba" {
   api_token = ""
 }
 
-# Authenticated YBA provider: its token comes from the customer created above,
-# so Terraform configures it only after the customer exists and YBA is up. Used
-# to create the cloud provider whose survival this test asserts.
+# Authenticated YBA provider: token comes from the customer above, so it
+# configures only after YBA is up; creates the provider whose survival is asserted.
 provider "yba" {
   host         = google_compute_address.yba.address
   api_token    = yba_customer_resource.customer.api_token
@@ -295,17 +263,15 @@ resource "tls_private_key" "yba" {
   rsa_bits  = 4096
 }
 
-# Static external IP so the YBA host/API address stays constant across the VM
-# reimage (the VM is replaced; this address is reused).
+# Static external IP so the YBA address stays constant across the VM reimage.
 resource "google_compute_address" "yba" {
   name         = "%[1]s"
   region       = var.GCP_REGION
   address_type = "EXTERNAL"
 }
 
-# Persistent YBA state on a separate disk. It is NOT recreated when the boot
-# image changes, so /opt/yugabyte/data outlives the host reimage; that survival
-# is the whole point of the test.
+# NOT recreated when the boot image changes: /opt/yugabyte/data outliving the
+# reimage is the point of the test.
 resource "google_compute_disk" "data" {
   name = "%[1]s-data"
   zone = "${var.GCP_REGION}-a"
@@ -320,8 +286,8 @@ resource "google_compute_instance" "yba" {
 
   allow_stopping_for_update = true
 
-  # Changing this image forces the VM to be replaced (GCP can't reimage a boot
-  # disk in place); that replacement is the "OS upgrade" under test.
+  # Changing this image replaces the VM (GCP can't reimage a boot disk in
+  # place); that replacement is the "OS upgrade" under test.
   boot_disk {
     initialize_params {
       image = %[2]s
@@ -366,8 +332,7 @@ resource "random_password" "customer" {
   override_special = "!#$%%*-_"
 }
 
-# The data disk is mounted at /opt/yugabyte/data by the VM startup script.
-# Block the install until the mount actually exists.
+# Block the install until the startup script has mounted /opt/yugabyte/data.
 resource "null_resource" "wait_for_data_mount" {
   triggers = {
     instance = google_compute_instance.yba.instance_id
@@ -400,8 +365,7 @@ resource "yba_installer" "install" {
   host_os                   = "linux"
   host_architecture         = "x86_64"
 
-  # When the boot image changes the VM is replaced; re-run the installer on the
-  # new host. The reinstall sees the re-attached, pre-populated
+  # Reinstall on the replaced VM: sees the re-attached, pre-populated
   # /opt/yugabyte/data and runs 'install --without-data', rehydrating YBA.
   lifecycle {
     replace_triggered_by = [google_compute_instance.yba]
@@ -444,9 +408,8 @@ resource "yba_gcp_provider" "test" {
 `, name, bootImageRef, bootScript, license, settings, ybaVersion)
 }
 
-// repoPath builds an absolute path to a repo-relative file from this test file's
-// compiled location (internal/installation), so file() references and the
-// license check resolve regardless of the test's working directory.
+// repoPath resolves repo-relative paths via runtime.Caller so file() references
+// and the license check work regardless of the test's working directory.
 func repoPath(parts ...string) string {
 	_, thisFile, _, ok := runtime.Caller(0)
 	if !ok {
@@ -458,9 +421,8 @@ func repoPath(parts ...string) string {
 
 var gcpNameInvalid = regexp.MustCompile(`[^a-z0-9-]`)
 
-// gcpSafeName coerces an acctest random name into a valid GCP resource name:
-// lowercase, only [a-z0-9-], starting with a letter and ending with a letter
-// or digit.
+// gcpSafeName coerces a random name to GCP naming rules: lowercase [a-z0-9-],
+// starting with a letter.
 func gcpSafeName(s string) string {
 	s = gcpNameInvalid.ReplaceAllString(strings.ToLower(s), "-")
 	s = strings.Trim(s, "-")

--- a/internal/installation/resource_yba_installer_os_upgrade_test.go
+++ b/internal/installation/resource_yba_installer_os_upgrade_test.go
@@ -38,7 +38,8 @@ import (
 // fixture, which must not be reimaged) with /opt/yugabyte/data on a separate
 // persistent disk, creates a yba_gcp_provider, then flips the boot image so
 // the VM is destroyed and recreated. The reinstall must rehydrate from the
-// surviving data disk: instance_id changes, provider UUID doesn't. Both images
+// surviving data disk: instance_id changes, the boot disk's GCP-reported
+// source image is the new one, provider UUID doesn't change. Both images
 // are AlmaLinux 9 — alma8's older Python fails YBA preflight. ~30 min (two
 // real YBA installs); missing TF_VAR_GCP_YBA_VERSION or repo-root license
 // skips the test rather than failing it.
@@ -50,6 +51,7 @@ func TestAccLong_YBA_GCP_OSImageUpgrade(t *testing.T) {
 
 	var providerUUIDBefore, providerUUIDAfter string
 	var instanceIDBefore, instanceIDAfter string
+	var bootImageBefore, bootImageAfter string
 
 	name := gcpSafeName(acctest.RandomName("ybaosup"))
 
@@ -80,6 +82,8 @@ func TestAccLong_YBA_GCP_OSImageUpgrade(t *testing.T) {
 					captureAttr("yba_gcp_provider.test", "id", &providerUUIDBefore),
 					captureAttr("google_compute_instance.yba", "instance_id",
 						&instanceIDBefore),
+					checkBootDiskImage(t, "data.google_compute_image.old",
+						&bootImageBefore),
 				),
 			},
 			{
@@ -90,6 +94,9 @@ func TestAccLong_YBA_GCP_OSImageUpgrade(t *testing.T) {
 					captureAttr("yba_gcp_provider.test", "id", &providerUUIDAfter),
 					captureAttr("google_compute_instance.yba", "instance_id",
 						&instanceIDAfter),
+					checkBootDiskImage(t, "data.google_compute_image.new",
+						&bootImageAfter),
+					checkBootImageChanged(t, &bootImageBefore, &bootImageAfter),
 					checkOSUpgradePreservedProvider(t,
 						&instanceIDBefore, &instanceIDAfter,
 						&providerUUIDBefore, &providerUUIDAfter),
@@ -123,14 +130,60 @@ func checkOSUpgradePreservedProvider(t *testing.T,
 					"YBA state did not survive the host reimage",
 				*provBefore, *provAfter)
 		}
-		oldImg := stateAttr(s, "data.google_compute_image.old", "self_link")
-		newImg := stateAttr(s, "data.google_compute_image.new", "self_link")
-		t.Logf("VERIFIED OS image upgrade: YBA host VM reimaged from %s to %s "+
-			"(instance_id %s -> %s)", oldImg, newImg, *instBefore, *instAfter)
+		t.Logf("VERIFIED host reimaged: instance_id %s -> %s", *instBefore, *instAfter)
 		t.Logf("VERIFIED provider preserved: yba_gcp_provider %s was not recreated "+
 			"across the reimage (same UUID before and after)", *provAfter)
 		return nil
 	}
+}
+
+// checkBootDiskImage verifies the VM's boot disk was created from the image
+// wantImageDS resolved: data.google_compute_disk.boot reads the disk's
+// sourceImage back from GCP, so a config echo can't satisfy it. Compared by
+// image name — GCP may return the URL under a different API prefix than the
+// image self_link. Records the name in out for cross-step comparison.
+func checkBootDiskImage(
+	t *testing.T, wantImageDS string, out *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		got := stateAttr(s, "data.google_compute_disk.boot", "image")
+		want := stateAttr(s, wantImageDS, "self_link")
+		if got == "" || want == "" {
+			return fmt.Errorf(
+				"boot disk image (%q) or %s self_link (%q) missing from state",
+				got, wantImageDS, want)
+		}
+		if imageName(got) != imageName(want) {
+			return fmt.Errorf("boot disk was created from image %s, expected %s (%s)",
+				got, want, wantImageDS)
+		}
+		*out = imageName(got)
+		t.Logf("boot disk source image on GCP is %s (matches %s)",
+			imageName(got), wantImageDS)
+		return nil
+	}
+}
+
+// checkBootImageChanged guards against old/new resolving to the same image, so
+// "reimaged" can't pass vacuously.
+func checkBootImageChanged(t *testing.T, before, after *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *before == "" || *after == "" {
+			return errors.New("boot disk image was not captured in both steps")
+		}
+		if *before == *after {
+			return fmt.Errorf(
+				"boot disk image did not change across the upgrade (still %s)", *before)
+		}
+		t.Logf("VERIFIED OS image upgrade: boot disk source image %s -> %s "+
+			"(read back from GCP)", *before, *after)
+		return nil
+	}
+}
+
+// imageName is the last path segment of an image URL; unique within a project.
+func imageName(link string) string {
+	parts := strings.Split(link, "/")
+	return parts[len(parts)-1]
 }
 
 // checkProviderStillOnYBA asks the rehydrated YBA (host/token from state, not
@@ -321,6 +374,14 @@ resource "google_compute_instance" "yba" {
     email  = jsondecode(var.GCP_CREDENTIALS).client_email
     scopes = ["cloud-platform"]
   }
+}
+
+# The instance's boot disk read back from GCP: its image attribute is the
+# disk's actual sourceImage, so the reimage is verified against GCP rather
+# than echoing the config.
+data "google_compute_disk" "boot" {
+  name = reverse(split("/", google_compute_instance.yba.boot_disk[0].source))[0]
+  zone = "${var.GCP_REGION}-a"
 }
 
 resource "random_password" "customer" {

--- a/internal/installation/resource_yba_installer_os_upgrade_test.go
+++ b/internal/installation/resource_yba_installer_os_upgrade_test.go
@@ -1,0 +1,475 @@
+// Licensed to YugabyteDB, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Mozilla License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://mozilla.org/MPL/2.0/.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package installation_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
+	"github.com/yugabyte/terraform-provider-yba/internal/acctest"
+	"github.com/yugabyte/terraform-provider-yba/internal/api"
+)
+
+// TestAccLong_YBA_GCP_OSImageUpgrade exercises the data-disk rehydration flow
+// end-to-end on a throwaway YBA stand it deploys itself (NOT the shared standing
+// fixture YBA, which other tests depend on and must not be reimaged).
+//
+// OLD and NEW are resolved automatically as the two most recent AlmaLinux 9
+// images (NEW = the family head, OLD = the next most recent), so nothing pins a
+// specific image. Both are AlmaLinux 9 on purpose: YBA installs the same way on
+// each, whereas the alma8 family ships an older Python that YBA's preflight
+// rejects.
+//
+// Flow:
+//  1. Stand up a fresh GCP VM (boot image = OLD) with a separate persistent data
+//     disk mounted at /opt/yugabyte/data, install YBA over SSH via yba_installer,
+//     register the first customer, and create a yba_gcp_provider through that YBA.
+//  2. Flip the VM boot image OLD -> NEW. GCP can't reimage in place, so the VM is
+//     destroyed and recreated; the data disk is NOT recreated and re-attaches to
+//     the new VM, the startup script re-mounts /opt/yugabyte/data, and the
+//     installer (wired with replace_triggered_by on the VM) re-runs. Because the
+//     data dir is now populated it installs with --without-data, rehydrating YBA
+//     from the surviving disk.
+//
+// Assertions:
+//   - The VM was actually reimaged (its server-assigned instance_id changed).
+//   - The yba_gcp_provider was NOT recreated (its UUID is unchanged) AND it still
+//     exists in the rehydrated YBA — i.e. no YBA state was lost across the host
+//     OS-image upgrade.
+//
+// This is a long test (~30 min: two YBA installs on real GCP). It reuses the
+// standing fixture's network/project/credentials but stands up its OWN VM, data
+// disk, YBA install, and cloud provider — none of the standing fixture's
+// resources are modified — and tears them all down at the end (resource.Test
+// runs destroy even on failure). It needs only the standing fixture env,
+// TF_VAR_GCP_YBA_VERSION, and the YBA license at the repo root; any missing ->
+// the test skips, not fails.
+func TestAccLong_YBA_GCP_OSImageUpgrade(t *testing.T) {
+	ybaVersion := os.Getenv("TF_VAR_GCP_YBA_VERSION")
+	licensePath := repoPath("yugabyte_anywhere.lic")
+	settingsPath := repoPath("acctest", "resources", "yba-ctl.yml")
+	bootScriptPath := repoPath("acctest", "resources", "gcp-bootscript.sh")
+
+	// Captured from Terraform state between the two steps.
+	var providerUUIDBefore, providerUUIDAfter string
+	var instanceIDBefore, instanceIDAfter string
+
+	name := gcpSafeName(acctest.RandomName("ybaosup"))
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.TestAccPreCheckGCP(t)
+			if ybaVersion == "" {
+				t.Skip("TF_VAR_GCP_YBA_VERSION not set; skipping YBA OS-image-upgrade test")
+			}
+			if _, err := os.Stat(licensePath); err != nil {
+				t.Skipf("YBA license not found at %s; skipping YBA OS-image-upgrade test",
+					licensePath)
+			}
+		},
+		// yba comes from the in-process factory; the infra providers are pulled
+		// from the registry for the duration of the test.
+		ProviderFactories: acctest.ProviderFactories,
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"google": {Source: "hashicorp/google", VersionConstraint: ">= 5.0"},
+			"tls":    {Source: "hashicorp/tls", VersionConstraint: ">= 4.0"},
+			"random": {Source: "hashicorp/random", VersionConstraint: ">= 3.0"},
+			"null":   {Source: "hashicorp/null", VersionConstraint: ">= 3.0"},
+		},
+		Steps: []resource.TestStep{
+			{
+				Config: osUpgradeGCPConfig(name,
+					"data.google_compute_image.old.self_link", ybaVersion,
+					bootScriptPath, licensePath, settingsPath),
+				Check: resource.ComposeTestCheckFunc(
+					captureAttr("yba_gcp_provider.test", "id", &providerUUIDBefore),
+					captureAttr("google_compute_instance.yba", "instance_id",
+						&instanceIDBefore),
+				),
+			},
+			{
+				Config: osUpgradeGCPConfig(name,
+					"data.google_compute_image.new.self_link", ybaVersion,
+					bootScriptPath, licensePath, settingsPath),
+				Check: resource.ComposeTestCheckFunc(
+					captureAttr("yba_gcp_provider.test", "id", &providerUUIDAfter),
+					captureAttr("google_compute_instance.yba", "instance_id",
+						&instanceIDAfter),
+					checkOSUpgradePreservedProvider(t,
+						&instanceIDBefore, &instanceIDAfter,
+						&providerUUIDBefore, &providerUUIDAfter),
+					checkProviderStillOnYBA(t, &providerUUIDAfter),
+				),
+			},
+		},
+	})
+}
+
+// checkOSUpgradePreservedProvider asserts the host was actually reimaged and the
+// cloud provider object was not recreated in the process.
+func checkOSUpgradePreservedProvider(t *testing.T,
+	instBefore, instAfter, provBefore, provAfter *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		if *instBefore == "" || *instAfter == "" {
+			return errors.New("instance_id was not captured in both steps")
+		}
+		if *instBefore == *instAfter {
+			return fmt.Errorf(
+				"expected the YBA host VM to be reimaged (instance_id change), "+
+					"but it stayed %s — the boot image change did not replace the VM",
+				*instBefore)
+		}
+		if *provBefore == "" || *provAfter == "" {
+			return errors.New("yba_gcp_provider id was not captured in both steps")
+		}
+		if *provBefore != *provAfter {
+			return fmt.Errorf(
+				"cloud provider was recreated across the OS upgrade (uuid %s -> %s); "+
+					"YBA state did not survive the host reimage",
+				*provBefore, *provAfter)
+		}
+		oldImg := stateAttr(s, "data.google_compute_image.old", "self_link")
+		newImg := stateAttr(s, "data.google_compute_image.new", "self_link")
+		t.Logf("VERIFIED OS image upgrade: YBA host VM reimaged from %s to %s "+
+			"(instance_id %s -> %s)", oldImg, newImg, *instBefore, *instAfter)
+		t.Logf("VERIFIED provider preserved: yba_gcp_provider %s was not recreated "+
+			"across the reimage (same UUID before and after)", *provAfter)
+		return nil
+	}
+}
+
+// checkProviderStillOnYBA queries the rehydrated YBA directly (using the host and
+// API token from state, not the shared fixture YBA) and confirms the provider
+// created before the upgrade is still present — the direct proof that
+// /opt/yugabyte/data survived.
+func checkProviderStillOnYBA(t *testing.T, providerUUID *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		host := stateAttr(s, "google_compute_address.yba", "address")
+		token := stateAttr(s, "yba_customer_resource.customer", "api_token")
+		if host == "" || token == "" {
+			return errors.New("could not read YBA host/api_token from state")
+		}
+
+		c, err := api.NewAPIClient(true, host, token)
+		if err != nil {
+			return fmt.Errorf("connecting to rehydrated YBA at %s: %w", host, err)
+		}
+
+		providers, _, err := c.YugawareClient.CloudProvidersAPI.
+			GetListOfProviders(context.Background(), c.CustomerID).Execute()
+		if err != nil {
+			return fmt.Errorf("listing providers on rehydrated YBA: %w", err)
+		}
+		for _, p := range providers {
+			if p.GetUuid() == *providerUUID {
+				t.Logf("VERIFIED data survived: cloud provider %s (name=%q code=%q) "+
+					"is still present on the rehydrated YBA at %s after the OS image "+
+					"upgrade — /opt/yugabyte/data persisted across the host reimage",
+					*providerUUID, p.GetName(), p.GetCode(), host)
+				return nil
+			}
+		}
+		return fmt.Errorf(
+			"cloud provider %s is gone from YBA after the OS upgrade; data was lost",
+			*providerUUID)
+	}
+}
+
+// captureAttr records a resource attribute from state into out for cross-step
+// comparison. The synthetic attribute name "id" reads Primary.ID.
+func captureAttr(resourceName, attr string, out *string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[resourceName]
+		if !ok {
+			return fmt.Errorf("resource not found in state: %s", resourceName)
+		}
+		if attr == "id" {
+			*out = rs.Primary.ID
+		} else {
+			*out = rs.Primary.Attributes[attr]
+		}
+		if *out == "" {
+			return fmt.Errorf("%s.%s is empty in state", resourceName, attr)
+		}
+		return nil
+	}
+}
+
+func stateAttr(s *terraform.State, resourceName, attr string) string {
+	rs, ok := s.RootModule().Resources[resourceName]
+	if !ok {
+		return ""
+	}
+	return rs.Primary.Attributes[attr]
+}
+
+// osUpgradeGCPConfig renders the throwaway-YBA-stand config. bootImageRef is an
+// HCL reference to the boot-image data source for this step (old then new);
+// everything else is constant so the only planned change between steps is the
+// host reimage.
+func osUpgradeGCPConfig(
+	name, bootImageRef, ybaVersion, bootScript, license, settings string) string {
+	return fmt.Sprintf(`
+variable "GCP_PROJECT_ID" { type = string }
+variable "GCP_REGION"     { type = string }
+variable "GCP_VPC_NETWORK" { type = string }
+variable "GCP_SUBNETWORK"  { type = string }
+
+variable "GCP_CREDENTIALS" {
+  type      = string
+  sensitive = true
+}
+
+provider "google" {
+  project     = var.GCP_PROJECT_ID
+  region      = var.GCP_REGION
+  credentials = var.GCP_CREDENTIALS
+}
+
+# Resolve the two most recent AlmaLinux 9 images so the upgrade is always between
+# real, current releases and nobody has to pin image names. new = the family
+# head (newest); old = the most recent almalinux-9 whose name differs from new,
+# i.e. the second newest.
+data "google_compute_image" "new" {
+  project     = "almalinux-cloud"
+  family      = "almalinux-9"
+  most_recent = true
+}
+
+data "google_compute_image" "old" {
+  project     = "almalinux-cloud"
+  most_recent = true
+  filter      = "(family = \"almalinux-9\") (name != \"${data.google_compute_image.new.name}\")"
+
+  lifecycle {
+    postcondition {
+      condition     = self.self_link != data.google_compute_image.new.self_link
+      error_message = "could not resolve a second-most-recent almalinux-9 image distinct from the newest"
+    }
+  }
+}
+
+# Bootstrap (tokenless) YBA provider: installs YBA and registers the first
+# customer on the freshly-created VM, before any API token exists.
+provider "yba" {
+  alias = "bootstrap"
+  host  = google_compute_address.yba.address
+
+  api_token = ""
+}
+
+# Authenticated YBA provider: its token comes from the customer created above,
+# so Terraform configures it only after the customer exists and YBA is up. Used
+# to create the cloud provider whose survival this test asserts.
+provider "yba" {
+  host         = google_compute_address.yba.address
+  api_token    = yba_customer_resource.customer.api_token
+  enable_https = true
+}
+
+resource "tls_private_key" "yba" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+# Static external IP so the YBA host/API address stays constant across the VM
+# reimage (the VM is replaced; this address is reused).
+resource "google_compute_address" "yba" {
+  name         = "%[1]s"
+  region       = var.GCP_REGION
+  address_type = "EXTERNAL"
+}
+
+# Persistent YBA state on a separate disk. It is NOT recreated when the boot
+# image changes, so /opt/yugabyte/data outlives the host reimage; that survival
+# is the whole point of the test.
+resource "google_compute_disk" "data" {
+  name = "%[1]s-data"
+  zone = "${var.GCP_REGION}-a"
+  type = "pd-balanced"
+  size = 250
+}
+
+resource "google_compute_instance" "yba" {
+  name         = "%[1]s"
+  machine_type = "n2-standard-4"
+  zone         = "${var.GCP_REGION}-a"
+
+  allow_stopping_for_update = true
+
+  # Changing this image forces the VM to be replaced (GCP can't reimage a boot
+  # disk in place); that replacement is the "OS upgrade" under test.
+  boot_disk {
+    initialize_params {
+      image = %[2]s
+      size  = 100
+      type  = "pd-balanced"
+    }
+  }
+
+  # device_name must match the VM hostname; the startup script resolves the data
+  # disk at /dev/disk/by-id/google-$(hostname -s).
+  attached_disk {
+    source      = google_compute_disk.data.self_link
+    device_name = "%[1]s"
+  }
+
+  network_interface {
+    network    = var.GCP_VPC_NETWORK
+    subnetwork = var.GCP_SUBNETWORK
+
+    access_config {
+      nat_ip = google_compute_address.yba.address
+    }
+  }
+
+  metadata = {
+    ssh-keys       = "yugabyte:${tls_private_key.yba.public_key_openssh}"
+    startup-script = file("%[3]s")
+  }
+
+  service_account {
+    email  = jsondecode(var.GCP_CREDENTIALS).client_email
+    scopes = ["cloud-platform"]
+  }
+}
+
+resource "random_password" "customer" {
+  length           = 16
+  min_upper        = 1
+  min_lower        = 1
+  min_numeric      = 1
+  min_special      = 1
+  override_special = "!#$%%*-_"
+}
+
+# The data disk is mounted at /opt/yugabyte/data by the VM startup script.
+# Block the install until the mount actually exists.
+resource "null_resource" "wait_for_data_mount" {
+  triggers = {
+    instance = google_compute_instance.yba.instance_id
+  }
+
+  connection {
+    type        = "ssh"
+    host        = google_compute_address.yba.address
+    user        = "yugabyte"
+    private_key = tls_private_key.yba.private_key_openssh
+    timeout     = "10m"
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "for i in $(seq 1 120); do mountpoint -q /opt/yugabyte/data && exit 0; sleep 5; done; echo 'timed out waiting for /opt/yugabyte/data to mount' >&2; exit 1",
+    ]
+  }
+}
+
+resource "yba_installer" "install" {
+  provider = yba.bootstrap
+
+  ssh_host_ip               = google_compute_address.yba.address
+  ssh_user                  = "yugabyte"
+  ssh_private_key           = tls_private_key.yba.private_key_openssh
+  yba_license_file          = "%[4]s"
+  application_settings_file = "%[5]s"
+  yba_version               = "%[6]s"
+  host_os                   = "linux"
+  host_architecture         = "x86_64"
+
+  # When the boot image changes the VM is replaced; re-run the installer on the
+  # new host. The reinstall sees the re-attached, pre-populated
+  # /opt/yugabyte/data and runs 'install --without-data', rehydrating YBA.
+  lifecycle {
+    replace_triggered_by = [google_compute_instance.yba]
+  }
+
+  depends_on = [null_resource.wait_for_data_mount]
+}
+
+resource "yba_customer_resource" "customer" {
+  provider = yba.bootstrap
+
+  code     = "admin"
+  email    = "admin@example.com"
+  name     = "admin"
+  password = random_password.customer.result
+
+  lifecycle {
+    ignore_changes = [password]
+  }
+
+  depends_on = [yba_installer.install]
+}
+
+resource "yba_gcp_provider" "test" {
+  name        = "%[1]s-provider"
+  credentials = var.GCP_CREDENTIALS
+  project_id  = var.GCP_PROJECT_ID
+  network     = var.GCP_VPC_NETWORK
+  regions {
+    code          = var.GCP_REGION
+    shared_subnet = var.GCP_SUBNETWORK
+  }
+  yba_managed_image_bundles {
+    arch = "x86_64"
+  }
+  air_gap_install = false
+
+  depends_on = [yba_customer_resource.customer]
+}
+`, name, bootImageRef, bootScript, license, settings, ybaVersion)
+}
+
+// repoPath builds an absolute path to a repo-relative file from this test file's
+// compiled location (internal/installation), so file() references and the
+// license check resolve regardless of the test's working directory.
+func repoPath(parts ...string) string {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		return filepath.Join(parts...)
+	}
+	root := filepath.Join(filepath.Dir(thisFile), "..", "..")
+	return filepath.Join(append([]string{root}, parts...)...)
+}
+
+var gcpNameInvalid = regexp.MustCompile(`[^a-z0-9-]`)
+
+// gcpSafeName coerces an acctest random name into a valid GCP resource name:
+// lowercase, only [a-z0-9-], starts with a letter, ends with a letter/digit,
+// and short enough to leave room for the "-data"/"-provider" suffixes this test
+// appends (GCP caps names at 63 chars).
+func gcpSafeName(s string) string {
+	s = gcpNameInvalid.ReplaceAllString(strings.ToLower(s), "-")
+	s = strings.Trim(s, "-")
+	if s == "" || s[0] < 'a' || s[0] > 'z' {
+		s = "yba-" + s
+	}
+	if len(s) > 45 {
+		s = strings.TrimRight(s[:45], "-")
+	}
+	return s
+}

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -16,6 +16,7 @@
 package installation
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -564,8 +565,7 @@ func TestGetInstallCommandsDataDirBranch(t *testing.T) {
 	last := cmds[len(cmds)-1]
 
 	wantSubstrings := []string{
-		`if [ -d /opt/yugabyte/data ]`,
-		`[ -n "$(sudo ls -A /opt/yugabyte/data 2>/dev/null)" ]`,
+		`if sudo test -d /opt/yugabyte/data/yb-platform; then`,
 		`yba-ctl install -f --without-data -s diskAvailability`,
 		`/opt/yba-ctl/yba-ctl start`,
 		`else sudo ./yba_installer_full-2024.1.0.0-b129/yba-ctl install -f -s diskAvailability;`,
@@ -638,20 +638,33 @@ func TestGetReconfigureCommands(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cmds := getReconfigureCommands(tt.version)
-			if len(cmds) != 2 {
-				t.Fatalf("expected 2 commands, got %d: %v", len(cmds), cmds)
+			cmds := getReconfigureCommands(tt.version, "linux", "x86_64")
+			if len(cmds) != 3 {
+				t.Fatalf("expected 3 commands, got %d: %v", len(cmds), cmds)
 			}
 			if !strings.Contains(cmds[0], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
 				t.Errorf("expected settings move first, got %q", cmds[0])
 			}
-			if !strings.Contains(cmds[1], "/opt/yba-ctl/yba-ctl reconfigure -f") {
-				t.Errorf("expected reconfigure second, got %q", cmds[1])
+			// On-demand bundle fetch guarded by a dir-existence check, so a
+			// reconfigure-only apply doesn't depend on the extracted bundle
+			// surviving in the SSH user's home from a prior apply.
+			folder := fmt.Sprintf("yba_installer_full-%s", tt.version)
+			if !strings.Contains(cmds[1], fmt.Sprintf("[ -d ~/%s ] ||", folder)) {
+				t.Errorf("expected guarded bundle fetch second, got %q", cmds[1])
 			}
-			hasEnv := strings.Contains(cmds[1], "YBA_MODE=dev")
+			if !strings.Contains(cmds[1], "curl -O") || !strings.Contains(cmds[1], "tar -xf") {
+				t.Errorf("expected curl/tar download in fetch guard, got %q", cmds[1])
+			}
+			if !strings.Contains(cmds[2], fmt.Sprintf("cd ~/%s", folder)) {
+				t.Errorf("expected cd into bundle dir, got %q", cmds[2])
+			}
+			if !strings.Contains(cmds[2], "/opt/yba-ctl/yba-ctl reconfigure -f") {
+				t.Errorf("expected reconfigure third, got %q", cmds[2])
+			}
+			hasEnv := strings.Contains(cmds[2], "YBA_MODE=dev")
 			if hasEnv != tt.expectedEnv {
 				t.Errorf("YBA_MODE=dev presence = %v, expected %v in %q",
-					hasEnv, tt.expectedEnv, cmds[1])
+					hasEnv, tt.expectedEnv, cmds[2])
 			}
 		})
 	}

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -508,15 +508,91 @@ func TestGetBundleDownloadCommands(t *testing.T) {
 
 func TestGetInstallCommandsWithConfig(t *testing.T) {
 	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", true, nil)
-	// Expected order: curl, tar, license add, mv settings.yml, install
-	if len(cmds) != 5 {
-		t.Fatalf("expected 5 commands when config=true, got %d: %v", len(cmds), cmds)
+	// Expected order: curl, tar, license add, mkdir /opt/yba-ctl,
+	// mv settings.yml, combined install (bash if-else).
+	if len(cmds) != 6 {
+		t.Fatalf("expected 6 commands when config=true, got %d: %v", len(cmds), cmds)
 	}
-	if !strings.Contains(cmds[3], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
-		t.Errorf("expected settings move at index 3, got %q", cmds[3])
+	if !strings.Contains(cmds[3], "mkdir -p /opt/yba-ctl") {
+		t.Errorf("expected /opt/yba-ctl mkdir at index 3, got %q", cmds[3])
 	}
-	if !strings.Contains(cmds[4], "yba-ctl install -f") {
-		t.Errorf("expected install command at index 4, got %q", cmds[4])
+	if !strings.Contains(cmds[4], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
+		t.Errorf("expected settings move at index 4, got %q", cmds[4])
+	}
+	last := cmds[len(cmds)-1]
+	if !strings.Contains(last, "yba-ctl install -f") {
+		t.Errorf("expected combined install command, got %q", last)
+	}
+	if !strings.Contains(last, "--without-data") {
+		t.Errorf("expected combined install to include --without-data branch, got %q", last)
+	}
+}
+
+// TestGetInstallCommandsWithoutConfig verifies that when no
+// application_settings input is supplied, the function does not stage
+// /opt/yba-ctl/yba-ctl.yml. The combined install must still be the last
+// command so callers that grep cmds[len-1] for the install flags keep
+// working.
+func TestGetInstallCommandsWithoutConfig(t *testing.T) {
+	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", false, nil)
+	if len(cmds) != 4 {
+		t.Fatalf("expected 4 commands when config=false, got %d: %v", len(cmds), cmds)
+	}
+	for i, cmd := range cmds {
+		if strings.Contains(cmd, "mkdir -p /opt/yba-ctl") {
+			t.Errorf("did not expect /opt/yba-ctl mkdir when config=false, found at %d: %q",
+				i, cmd)
+		}
+		if strings.Contains(cmd, "mv /tmp/settings.yml") {
+			t.Errorf("did not expect settings move when config=false, found at %d: %q",
+				i, cmd)
+		}
+	}
+	last := cmds[len(cmds)-1]
+	if !strings.Contains(last, "yba-ctl install -f") {
+		t.Errorf("expected install -f in last command, got %q", last)
+	}
+}
+
+// TestGetInstallCommandsDataDirBranch locks in the bash structure that
+// picks between fresh install and --without-data install. A regression
+// here would silently re-initialise storage on a host that booted with
+// a pre-populated /opt/yugabyte/data disk attached.
+func TestGetInstallCommandsDataDirBranch(t *testing.T) {
+	skip := []string{"diskAvailability"}
+	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", true, &skip)
+	last := cmds[len(cmds)-1]
+
+	wantSubstrings := []string{
+		`if [ -d /opt/yugabyte/data ]`,
+		`[ -n "$(sudo ls -A /opt/yugabyte/data 2>/dev/null)" ]`,
+		`yba-ctl install -f --without-data -s diskAvailability`,
+		`/opt/yba-ctl/yba-ctl start`,
+		`else sudo ./yba_installer_full-2024.1.0.0-b129/yba-ctl install -f -s diskAvailability;`,
+		`fi`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(last, want) {
+			t.Errorf("combined install missing %q, got %q", want, last)
+		}
+	}
+}
+
+// TestGetInstallCommandsDataDirBranchPreRelease confirms YBA_MODE=dev
+// propagates into both branches and the yba-ctl start fallback.
+func TestGetInstallCommandsDataDirBranchPreRelease(t *testing.T) {
+	cmds := getInstallCommands("2.25.0.0-b300", "linux", "x86_64", false, nil)
+	last := cmds[len(cmds)-1]
+
+	wantSubstrings := []string{
+		`sudo YBA_MODE=dev ./yba_installer_full-2.25.0.0-b300/yba-ctl install -f --without-data`,
+		`sudo YBA_MODE=dev /opt/yba-ctl/yba-ctl start`,
+		`else sudo YBA_MODE=dev ./yba_installer_full-2.25.0.0-b300/yba-ctl install -f;`,
+	}
+	for _, want := range wantSubstrings {
+		if !strings.Contains(last, want) {
+			t.Errorf("combined install missing %q, got %q", want, last)
+		}
 	}
 }
 
@@ -677,26 +753,37 @@ func TestGetDeleteCommands(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmds := getDeleteCommands(tt.version)
-			if len(cmds) != 3 {
-				t.Fatalf("expected 3 commands (clean, rm yugabyte, rm tmp), got %d: %v",
+			if len(cmds) != 2 {
+				t.Fatalf("expected 2 commands (clean, rm tmp), got %d: %v",
 					len(cmds), cmds)
 			}
 			if !strings.Contains(cmds[0], "/opt/yba-ctl/yba-ctl clean") {
 				t.Errorf("expected clean command first, got %q", cmds[0])
+			}
+			// `--all` would wipe /opt/yugabyte/data which must outlive
+			// the resource when a separate data disk is mounted there.
+			if strings.Contains(cmds[0], "--all") {
+				t.Errorf("clean must not pass --all, got %q", cmds[0])
 			}
 			hasEnv := strings.Contains(cmds[0], "YBA_MODE=dev")
 			if hasEnv != tt.expectedEnv {
 				t.Errorf("YBA_MODE=dev presence = %v, expected %v in %q",
 					hasEnv, tt.expectedEnv, cmds[0])
 			}
-			if cmds[1] != "sudo rm -rf /opt/yugabyte" {
-				t.Errorf("expected rm -rf /opt/yugabyte, got %q", cmds[1])
+			if !strings.Contains(cmds[1], "/tmp/server.crt") ||
+				!strings.Contains(cmds[1], "/tmp/server.key") ||
+				!strings.Contains(cmds[1], "/tmp/license.lic") ||
+				!strings.Contains(cmds[1], "/tmp/settings.yml") {
+				t.Errorf("expected rm of all tmp files, got %q", cmds[1])
 			}
-			if !strings.Contains(cmds[2], "/tmp/server.crt") ||
-				!strings.Contains(cmds[2], "/tmp/server.key") ||
-				!strings.Contains(cmds[2], "/tmp/license.lic") ||
-				!strings.Contains(cmds[2], "/tmp/settings.yml") {
-				t.Errorf("expected rm of all tmp files, got %q", cmds[2])
+			// Regression: an earlier version of this function ran
+			// `sudo rm -rf /opt/yugabyte`, which would wipe the data
+			// disk on every destroy/replace cycle.
+			for i, cmd := range cmds {
+				if strings.Contains(cmd, "rm -rf /opt/yugabyte") {
+					t.Errorf("delete commands must not wipe /opt/yugabyte, found at %d: %q",
+						i, cmd)
+				}
 			}
 		})
 	}

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -529,11 +529,6 @@ func TestGetInstallCommandsWithConfig(t *testing.T) {
 	}
 }
 
-// TestGetInstallCommandsWithoutConfig verifies that when no
-// application_settings input is supplied, the function does not stage
-// /opt/yba-ctl/yba-ctl.yml. The combined install must still be the last
-// command so callers that grep cmds[len-1] for the install flags keep
-// working.
 func TestGetInstallCommandsWithoutConfig(t *testing.T) {
 	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", false, nil)
 	if len(cmds) != 4 {
@@ -555,10 +550,8 @@ func TestGetInstallCommandsWithoutConfig(t *testing.T) {
 	}
 }
 
-// TestGetInstallCommandsDataDirBranch locks in the bash structure that
-// picks between fresh install and --without-data install. A regression
-// here would silently re-initialise storage on a host that booted with
-// a pre-populated /opt/yugabyte/data disk attached.
+// A regression in the install branching would silently re-initialise storage
+// on a host with a pre-populated /opt/yugabyte/data disk attached.
 func TestGetInstallCommandsDataDirBranch(t *testing.T) {
 	skip := []string{"diskAvailability"}
 	cmds := getInstallCommands("2024.1.0.0-b129", "linux", "x86_64", true, &skip)
@@ -578,8 +571,6 @@ func TestGetInstallCommandsDataDirBranch(t *testing.T) {
 	}
 }
 
-// TestGetInstallCommandsDataDirBranchPreRelease confirms YBA_MODE=dev
-// propagates into both branches and the yba-ctl start fallback.
 func TestGetInstallCommandsDataDirBranchPreRelease(t *testing.T) {
 	cmds := getInstallCommands("2.25.0.0-b300", "linux", "x86_64", false, nil)
 	last := cmds[len(cmds)-1]
@@ -645,9 +636,6 @@ func TestGetReconfigureCommands(t *testing.T) {
 			if !strings.Contains(cmds[0], "mv /tmp/settings.yml /opt/yba-ctl/yba-ctl.yml") {
 				t.Errorf("expected settings move first, got %q", cmds[0])
 			}
-			// On-demand bundle fetch guarded by a dir-existence check, so a
-			// reconfigure-only apply doesn't depend on the extracted bundle
-			// surviving in the SSH user's home from a prior apply.
 			folder := fmt.Sprintf("yba_installer_full-%s", tt.version)
 			if !strings.Contains(cmds[1], fmt.Sprintf("[ -d ~/%s ] ||", folder)) {
 				t.Errorf("expected guarded bundle fetch second, got %q", cmds[1])
@@ -773,8 +761,7 @@ func TestGetDeleteCommands(t *testing.T) {
 			if !strings.Contains(cmds[0], "/opt/yba-ctl/yba-ctl clean") {
 				t.Errorf("expected clean command first, got %q", cmds[0])
 			}
-			// `--all` would wipe /opt/yugabyte/data which must outlive
-			// the resource when a separate data disk is mounted there.
+			// --all would wipe /opt/yugabyte/data, which must outlive the resource.
 			if strings.Contains(cmds[0], "--all") {
 				t.Errorf("clean must not pass --all, got %q", cmds[0])
 			}
@@ -789,9 +776,8 @@ func TestGetDeleteCommands(t *testing.T) {
 				!strings.Contains(cmds[1], "/tmp/settings.yml") {
 				t.Errorf("expected rm of all tmp files, got %q", cmds[1])
 			}
-			// Regression: an earlier version of this function ran
-			// `sudo rm -rf /opt/yugabyte`, which would wipe the data
-			// disk on every destroy/replace cycle.
+			// Earlier code ran `rm -rf /opt/yugabyte`, wiping the data disk on
+			// every destroy/replace cycle.
 			for i, cmd := range cmds {
 				if strings.Contains(cmd, "rm -rf /opt/yugabyte") {
 					t.Errorf("delete commands must not wipe /opt/yugabyte, found at %d: %q",

--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -18,6 +18,7 @@ package installation
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"strings"
@@ -46,6 +47,91 @@ func newSSHClient(user string, ip string, key string) (*ssh.Client, error) {
 		return nil, err
 	}
 	return c, nil
+}
+
+// Bounds for connectSSHForDelete. These cap only the failure path: a healthy
+// host answers on the first attempt and returns immediately. The total wall
+// time spent retrying an unreachable host is roughly sshConnectBudget, plus at
+// most one in-flight sshDialTimeout of overshoot (ssh.Dial is not
+// context-aware, so a dial already in progress runs to its own timeout).
+const (
+	sshDialTimeout   = 8 * time.Second
+	sshRetryInterval = 4 * time.Second
+	sshConnectBudget = 30 * time.Second
+)
+
+// errSSHHostUnreachable reports that every connection attempt failed at the
+// TCP layer within the retry budget, i.e. the host never answered. It is
+// distinguished by error *type* (*net.OpError), not by parsing OpenSSH error
+// strings, which vary across machines.
+var errSSHHostUnreachable = errors.New("ssh host unreachable after retries")
+
+// connectSSHForDelete establishes an SSH connection for resource teardown,
+// retrying transient TCP-layer failures within sshConnectBudget. It classifies
+// the outcome so the caller can tell "host is gone" apart from "host is alive
+// but we can't get in":
+//
+//   - (client, nil): the host answered; the caller must Close it. Returned on
+//     the first successful attempt, so a healthy host is never delayed.
+//   - (nil, errSSHHostUnreachable): no TCP connection within the budget. The
+//     host is effectively gone (e.g. the cloud VM was destroyed first in a
+//     replace cycle) — there is nothing to clean up remotely.
+//   - (nil, err): a malformed key, or an SSH handshake/auth failure. The host
+//     answered on the port, so it is alive and retrying cannot help; the
+//     caller should surface this and fail loudly rather than drop the resource.
+func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client, error) {
+	signer, err := ssh.ParsePrivateKey([]byte(key))
+	if err != nil {
+		// A bad/unparseable key is a config error, deterministic across
+		// retries and unrelated to whether the host is gone.
+		return nil, err
+	}
+	config := &ssh.ClientConfig{
+		User:            user,
+		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
+		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
+		Timeout:         sshDialTimeout,
+	}
+	addr := net.JoinHostPort(ip, "22")
+
+	budgetCtx, cancel := context.WithTimeout(ctx, sshConnectBudget)
+	defer cancel()
+
+	var lastErr error
+	for attempt := 1; budgetCtx.Err() == nil; attempt++ {
+		client, dialErr := ssh.Dial("tcp", addr, config)
+		if dialErr == nil {
+			return client, nil
+		}
+		lastErr = dialErr
+
+		// A *net.OpError is a TCP-layer failure (connection refused, dial
+		// timeout, no route to host): the host did not answer, so retrying
+		// helps if it is mid-teardown or briefly unreachable. Anything else is
+		// an SSH handshake/auth failure — the host answered and is alive, so
+		// bad credentials won't be fixed by retrying. Type-based, so it does
+		// not depend on OpenSSH-specific error text.
+		var netErr *net.OpError
+		if !errors.As(dialErr, &netErr) {
+			return nil, dialErr
+		}
+
+		tflog.Info(ctx, fmt.Sprintf(
+			"yba_installer: SSH dial to %s failed at TCP layer (attempt %d): %v",
+			addr, attempt, dialErr))
+
+		select {
+		case <-budgetCtx.Done():
+		case <-time.After(sshRetryInterval):
+		}
+	}
+
+	if ctx.Err() != nil {
+		// The caller's context was cancelled (not just our budget); propagate
+		// that rather than masquerading it as an unreachable host.
+		return nil, ctx.Err()
+	}
+	return nil, fmt.Errorf("%w: %v", errSSHHostUnreachable, lastErr)
 }
 
 func runCommand(ctx context.Context, client *ssh.Client, cmd string) (string, error) {

--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -49,41 +49,25 @@ func newSSHClient(user string, ip string, key string) (*ssh.Client, error) {
 	return c, nil
 }
 
-// Bounds for connectSSHForDelete. These cap only the failure path: a healthy
-// host answers on the first attempt and returns immediately. The total wall
-// time spent retrying an unreachable host is roughly sshConnectBudget, plus at
-// most one in-flight sshDialTimeout of overshoot (ssh.Dial is not
-// context-aware, so a dial already in progress runs to its own timeout).
+// connectSSHForDelete retry bounds. ssh.Dial is not context-aware, so retrying
+// can overshoot sshConnectBudget by one in-flight sshDialTimeout.
 const (
 	sshDialTimeout   = 8 * time.Second
 	sshRetryInterval = 4 * time.Second
 	sshConnectBudget = 30 * time.Second
 )
 
-// errSSHHostUnreachable reports that every connection attempt failed at the
-// TCP layer within the retry budget, i.e. the host never answered. It is
-// distinguished by error *type* (*net.OpError), not by parsing OpenSSH error
-// strings, which vary across machines.
+// errSSHHostUnreachable: every attempt failed at the TCP layer within the retry
+// budget — the host never answered.
 var errSSHHostUnreachable = errors.New("ssh host unreachable after retries")
 
-// connectSSHForDelete establishes an SSH connection for resource teardown,
-// retrying transient TCP-layer failures within sshConnectBudget. It classifies
-// the outcome so the caller can tell "host is gone" apart from "host is alive
-// but we can't get in":
-//
-//   - (client, nil): the host answered; the caller must Close it. Returned on
-//     the first successful attempt, so a healthy host is never delayed.
-//   - (nil, errSSHHostUnreachable): no TCP connection within the budget. The
-//     host is effectively gone (e.g. the cloud VM was destroyed first in a
-//     replace cycle) — there is nothing to clean up remotely.
-//   - (nil, err): a malformed key, or an SSH handshake/auth failure. The host
-//     answered on the port, so it is alive and retrying cannot help; the
-//     caller should surface this and fail loudly rather than drop the resource.
+// connectSSHForDelete dials SSH for teardown, retrying TCP-layer failures within
+// sshConnectBudget. Outcomes: (client, nil) host answered, caller must Close;
+// (nil, errSSHHostUnreachable) host gone, nothing to clean up remotely;
+// (nil, other) bad key or handshake/auth failure — host is alive, fail loudly.
 func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client, error) {
 	signer, err := ssh.ParsePrivateKey([]byte(key))
 	if err != nil {
-		// A bad/unparseable key is a config error, deterministic across
-		// retries and unrelated to whether the host is gone.
 		return nil, err
 	}
 	config := &ssh.ClientConfig{
@@ -105,12 +89,9 @@ func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client
 		}
 		lastErr = dialErr
 
-		// A *net.OpError is a TCP-layer failure (connection refused, dial
-		// timeout, no route to host): the host did not answer, so retrying
-		// helps if it is mid-teardown or briefly unreachable. Anything else is
-		// an SSH handshake/auth failure — the host answered and is alive, so
-		// bad credentials won't be fixed by retrying. Type-based, so it does
-		// not depend on OpenSSH-specific error text.
+		// *net.OpError = TCP-layer failure (refused, timeout, no route): host
+		// didn't answer, retry. Anything else = handshake/auth — host is alive,
+		// retrying won't help. Type check avoids OpenSSH-specific error text.
 		var netErr *net.OpError
 		if !errors.As(dialErr, &netErr) {
 			return nil, dialErr
@@ -127,8 +108,7 @@ func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client
 	}
 
 	if ctx.Err() != nil {
-		// The caller's context was cancelled (not just our budget); propagate
-		// that rather than masquerading it as an unreachable host.
+		// Caller cancellation is not "host unreachable"; propagate as-is.
 		return nil, ctx.Err()
 	}
 	return nil, fmt.Errorf("%w: %w", errSSHHostUnreachable, lastErr)

--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -131,7 +131,7 @@ func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client
 		// that rather than masquerading it as an unreachable host.
 		return nil, ctx.Err()
 	}
-	return nil, fmt.Errorf("%w: %v", errSSHHostUnreachable, lastErr)
+	return nil, fmt.Errorf("%w: %w", errSSHHostUnreachable, lastErr)
 }
 
 func runCommand(ctx context.Context, client *ssh.Client, cmd string) (string, error) {

--- a/templates/resources/installer.md.tmpl
+++ b/templates/resources/installer.md.tmpl
@@ -10,6 +10,15 @@ description: |-
 
 {{ .Description | trimspace }}
 
+## Supported Versions
+
+Both GA releases and pre-release CI builds are supported.
+
+| Version format        | Example           |
+| --------------------- | ----------------- |
+| GA release (`20YY.x`) | `2025.2.2.2-b11`  |
+| Pre-release (`2.xx`)  | `2.31.0.0-b14`    |
+
 ## Example Usage
 
 {{ tffile "examples/resources/yba_installer/resource.tf" }}


### PR DESCRIPTION
## Summary

  Lands the data-disk pieces of the BYOC branch onto main (telemetry is handled separately in #314), plus a new long acceptance test that proves YBA state survives a host OS-image upgrade. Four commits:

  1. Fixing reconfigure to also run from installed package directory — cherry-pick of 747cf25. yba-ctl reconfigure runs with the extracted installer bundle as CWD so its relative perf_advisor-*.tar.gz glob
  resolves.
  2. Adding support for install with data disk — cherry-pick of 78fe794. When /opt/yugabyte/data is already populated (a separately-managed persistent disk that survives the host VM), install runs --without-data
  and starts services in place; destroy runs yba-ctl clean only (no --all, no rm -rf /opt/yugabyte) so the data dir is preserved; and destroy skips remote SSH cleanup when the host is already gone (e.g. the VM was
  destroyed first in a replace cycle). The incidental load-balancer changes from the original squashed commit were dropped — that feature isn't on main yet. Docs are regenerated from templates/.
  3. Add long acceptance test for YBA-host OS-image upgrade (GCP) — see below.
  4. Use Standard_D2s_v4 for Azure universe acceptance-test nodes — small instance-type change for the existing Azure universe long tests.

###  OS-image-upgrade long test

  TestAccLong_YBA_GCP_OSImageUpgrade reuses the standing GCP fixture's network/project/credentials but stands up its own throwaway YBA — VM, persistent data disk, install, and a yba_gcp_provider — and tears it all
  down at the end. The standing fixture YBA is never touched.

  - Images are resolved automatically: the two most recent AlmaLinux 9 images (new = family head, old = next most recent) via google_compute_image data sources — nothing is pinned, no per-run config. Stays within
  AlmaLinux 9 (alma8's older Python fails YBA preflight).
  - Flow: step 1 installs YBA on the old image + creates a provider; step 2 flips the boot image to the new one → GCP replaces the VM → the data disk re-attaches, the startup script remounts /opt/yugabyte/data, and
  yba_installer (replace_triggered_by on the VM) re-runs → detects the populated data dir → installs --without-data, rehydrating YBA.
  - Asserts: the VM was actually reimaged (instance_id changed) and the cloud provider was not recreated (same UUID) and is still present on the rehydrated YBA. Verified facts are logged under go test -v.

  Two non-obvious fixes were needed to make it run reliably:
  - The bootstrap yba provider is forced unauthenticated (api_token = "") so it doesn't inherit the ambient YBA_API_KEY from acctest/env and call GetSessionInfo against an empty host during the harness's
  plan/refresh.
  - A null_resource blocks the install until /opt/yugabyte/data is actually mounted, so it can't race the async startup-script mount and land YBA's data on the boot disk (the 92 GiB < 200 GiB preflight failure).

  The test is defined inline (not a shared module) and reuses the standing fixture's gcp-bootscript.sh and yba-ctl.yml by reference, deliberately mirroring acctest/gcp/yba.tf — the lifecycles differ (ephemeral
  per-run stand vs. long-lived shared fixture), so they stay separate definitions. The gcp fixture exports TF_VAR_GCP_YBA_VERSION.

###  CI

  acctest-long.yml writes the existing YBA_LICENSE secret to the repo root so the test can install YBA. Absent the license (or TF_VAR_GCP_YBA_VERSION), the test skips rather than fails — so it's a no-op in any
  environment that doesn't have them.

##  Verification

  - go build ./..., go vet ./..., golangci-lint run ./... (0 issues), go test ./... (unit) — green.
  - make lint-docs — green (docs regenerated from templates). terraform validate on acctest/gcp — valid.
  - The long test was run end-to-end against a real GCP stand (TF_LOG=INFO TF_ACC=1 go test -v -run '^TestAccLong_YBA_GCP_OSImageUpgrade$') and passes: VM reimaged old→new, cloud provider survived on the rehydrated
  YBA.

###  To enable it in the nightly acctest-long run

  It runs automatically with the other TestAccLong* tests once ACCTEST_ENV carries TF_VAR_GCP_YBA_VERSION — refresh it via make -C acctest apply-gcp && make -C acctest push-github-secrets. The YBA_LICENSE secret is
  already in place.