### PR TITLE
Adding concurrency safety for short acceptance tests

### DIFF
--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -6,6 +6,18 @@ on:
   pull_request:
   workflow_dispatch:
 
+# Serialize every short acctest run against the one standing YBA (YBA_HOST). The
+# runtime-config tests mutate GLOBAL-scope singleton keys on that instance, so two
+# runs in parallel clobber each other's values (and one run's destroy resets a key
+# another run is mid-assertion on). A fixed, branch-independent group makes every
+# PR and push queue behind whichever run holds it. Never cancel an in-progress run:
+# its create->destroy cleanup must finish, or it leaves dangling overrides on the
+# shared YBA. The long workflow is deliberately NOT in this group — its universe
+# tests isolate by random resource names and are safe to run concurrently.
+concurrency:
+  group: standing-yba-acctest
+  cancel-in-progress: false
+
 jobs:
   # CI has no cloud access. The test env comes from the ACCTEST_ENV secret and
   # runs against the standing fixture, which is kept running out of band.

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -6,14 +6,6 @@ on:
   pull_request:
   workflow_dispatch:
 
-# Serialize every short acctest run against the one standing YBA (YBA_HOST). The
-# runtime-config tests mutate GLOBAL-scope singleton keys on that instance, so two
-# runs in parallel clobber each other's values (and one run's destroy resets a key
-# another run is mid-assertion on). A fixed, branch-independent group makes every
-# PR and push queue behind whichever run holds it. Never cancel an in-progress run:
-# its create->destroy cleanup must finish, or it leaves dangling overrides on the
-# shared YBA. The long workflow is deliberately NOT in this group — its universe
-# tests isolate by random resource names and are safe to run concurrently.
 concurrency:
   group: standing-yba-acctest
   cancel-in-progress: false


### PR DESCRIPTION
### Description
Occasionally short acceptance tests are failing because of concurrency issues where multiple runs hitting the same YBA don't clean up the old keys and such because of some unknown failure. 

```
=== Failed
=== FAIL: internal/runtimeconfig TestAccRuntimeConfig_GlobalScope (7.48s)
    resource_runtime_config_test.go:38: Step 3/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"value": "true",
        + 	"value": "false",
          }

=== FAIL: internal/runtimeconfig TestAccRuntimeConfig_TypeRoundTrip/boolean (6.33s)
    resource_runtime_config_test.go:94: Step 3/3 error running import: ImportStateVerify attributes not equivalent. Difference is shown below. The - symbol indicates attributes missing after import.
        
          map[string]string{
        - 	"value": "true",
        + 	"value": "false",
          }

=== FAIL: internal/runtimeconfig TestAccRuntimeConfig_TypeRoundTrip/duration (6.35s)
    testing_new.go:85: Error running post-test destroy, there may be dangling resources: runtime config key "yb.taskGC.gc_check_interval" in scope "00000000-0000-0000-0000-000000000000" still has test value "3 hours" after destroy

=== FAIL: internal/runtimeconfig TestAccRuntimeConfig_TypeRoundTrip/integer (4.90s)
    resource_runtime_config_test.go:94: Step 2/3 error: After applying this test step, the plan was not empty.
        stdout:
        
        
        Terraform used the selected providers to generate the following execution
        plan. Resource actions are indicated with the following symbols:
          ~ update in-place
        
        Terraform will perform the following actions:
        
          # yba_runtime_config.test will be updated in-place
          ~ resource "yba_runtime_config" "test" {
                id    = "00000000-0000-0000-0000-000000000000/yb.health.max_num_parallel_node_checks"
              ~ value = "50" -> "5"
                # (2 unchanged attributes hidden)
            }
        
        Plan: 0 to add, 1 to change, 0 to destroy.

=== FAIL: internal/runtimeconfig TestAccRuntimeConfig_TypeRoundTrip (24.02s)
```

Adds single key that is common for all short acceptance tests. May also need to add more cleanup before starting acceptance tests in case previous failed runs leave standing YBA in poor state. 