### PR TITLE
[PLAT-20608] Adding SSH port to yba installer

### DIFF
--- a/.github/workflows/acctest-long.yml
+++ b/.github/workflows/acctest-long.yml
@@ -9,6 +9,10 @@ on:
       - main
   workflow_dispatch:
 
+concurrency:
+  group: standing-yba-acctest-long
+  cancel-in-progress: false
+
 jobs:
   # `make acctest-long` opens the IAP tunnel to the standing YBA itself
   # (acctest/with-yba-tunnel.sh). The OS-image-upgrade test is the exception:

--- a/.github/workflows/acctest-long.yml
+++ b/.github/workflows/acctest-long.yml
@@ -10,6 +10,9 @@ on:
   workflow_dispatch:
 
 jobs:
+  # `make acctest-long` opens the IAP tunnel to the standing YBA itself
+  # (acctest/with-yba-tunnel.sh). The OS-image-upgrade test is the exception:
+  # its throwaway VM is tagged yba-install-target and reached directly.
   acctest-long:
     name: Acceptance Tests (Long)
     runs-on: ubuntu-latest

--- a/.github/workflows/acctest.yml
+++ b/.github/workflows/acctest.yml
@@ -14,8 +14,11 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # CI has no cloud access. The test env comes from the ACCTEST_ENV secret and
-  # runs against the standing fixture, which is kept running out of band.
+  # The test env comes from the ACCTEST_ENV secret and runs against the
+  # standing fixture, which is kept running out of band. The standing YBA has
+  # no direct ingress: `make acctest` itself opens the IAP tunnel
+  # (acctest/with-yba-tunnel.sh) as the fixture service account from the env —
+  # the same path a local run uses.
   acctest:
     name: Acceptance Tests
     runs-on: ubuntu-latest

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -103,10 +103,13 @@ test: $(GOTESTSUM)
 # Run the short acceptance tier (all TestAcc* except TestAccLong*). Sources
 # acctest/env, generated locally by `make -C acctest env` or written by CI from
 # the ACCTEST_ENV secret. Set TF_ACCTEST_PREFIX to override the resource prefix.
+# The standing YBA has no direct ingress; with-yba-tunnel.sh opens the IAP
+# tunnel (same path in CI and locally) unless one is already up.
 .PHONY: acctest
 acctest: install $(GOTESTSUM) acctest/env
 	@set -a; . ./acctest/env; set +a; \
-	TF_ACC=1 $(GOTESTSUM) -- -timeout 20m ./... -run '^TestAcc' -skip '^TestAccLong'
+	TF_ACC=1 ./acctest/with-yba-tunnel.sh \
+		$(GOTESTSUM) -- -timeout 20m ./... -run '^TestAcc' -skip '^TestAccLong'
 
 # Run the long acceptance tier (TestAccLong*). These deploy real multi-node
 # universes and take ~15 min each, so they stay out of `make acctest`. Same env
@@ -115,7 +118,8 @@ acctest: install $(GOTESTSUM) acctest/env
 .PHONY: acctest-long
 acctest-long: install $(GOTESTSUM) acctest/env
 	@set -a; . ./acctest/env; set +a; \
-	TF_ACC=1 $(GOTESTSUM) -- -timeout 90m ./... -run '^TestAccLong'
+	TF_ACC=1 ./acctest/with-yba-tunnel.sh \
+		$(GOTESTSUM) -- -timeout 90m ./... -run '^TestAccLong'
 
 acctest/env:
 	$(MAKE) -C acctest env

--- a/acctest/GNUmakefile
+++ b/acctest/GNUmakefile
@@ -45,6 +45,19 @@ destroy-%: init-%
 	@echo "Destroying $* fixture"
 	terraform -chdir=$* destroy # -auto-approve
 
+# gcp overrides: the standing YBA accepts no direct ingress, so apply/destroy
+# run under the tunnel script (-s adds the SSH leg the installer and yba-ctl
+# clean need), which waits for the API leg but proceeds on a fresh bootstrap.
+# Uses your gcloud login (no SA key exists yet on first apply — hence the auth
+# prerequisite): needs roles/iap.tunnelResourceAccessor or owner.
+apply-gcp: auth init-gcp
+	@echo "Applying gcp fixture (creates real cloud + YBA resources)"
+	./with-yba-tunnel.sh -s terraform -chdir=gcp apply -auto-approve
+
+destroy-gcp: auth init-gcp
+	@echo "Destroying gcp fixture"
+	./with-yba-tunnel.sh -s terraform -chdir=gcp destroy # -auto-approve
+
 # Write the test env (TF_VAR_*, plus YBA_HOST/YBA_API_KEY for the shared client)
 # into the gitignored, 0600 `env` file. Concatenates each fixture's test_env
 # output: gcp supplies the standing YBA endpoint and TF_VAR_GCP_*; azure supplies

--- a/acctest/README.md
+++ b/acctest/README.md
@@ -25,6 +25,18 @@ Terraform state the first time, then runs every `TestAcc*` (skipping the long
 tier, `TestAccLong*`). Re-run `make acctest` as often as you like. To run the
 long tier (multi-node universe deploys, ~15 min each): `make acctest-long`.
 
+The standing YBA VM has **no direct internet ingress** — every connection
+(UI, API, SSH) goes through an [IAP TCP forwarding](https://cloud.google.com/iap/docs/using-tcp-forwarding)
+tunnel, which authenticates callers with IAM before any packet reaches the VM.
+The env's YBA endpoints are therefore `127.0.0.1:9443`, and `make acctest`
+opens the tunnel itself (`acctest/with-yba-tunnel.sh`, the same path CI and
+the fixture targets use) as the fixture service account — no personal IAP
+grant or extra terminal needed. To browse the UI, hold a tunnel open with:
+
+```bash
+acctest/with-yba-tunnel.sh sleep 86400   # then open https://127.0.0.1:9443
+```
+
 If you see `acctest/env doesn't exist - extracting from TF state`, that is normal
 on the first run.
 
@@ -42,8 +54,13 @@ interactive), so run it yourself.
 
 ## Troubleshooting
 
-- **Auth error** (`could not find default credentials`, `403`): re-run
-  `make -C acctest auth`.
+- **Auth error** (`could not find default credentials`, `Reauthentication
+  failed`, `no usable gcloud login`, `403`): re-run `make -C acctest auth` —
+  it detects expired sessions, not just missing ones.
+- **`IAP tunnel ... did not become ready`** (or `connection refused` to
+  `127.0.0.1:9443`): check `gcloud` is installed and the env is fresh — the
+  tunnel authenticates as the fixture SA from `TF_VAR_GCP_CREDENTIALS`, so a
+  rotated key means a stale env (see below).
 - **Every test is SKIPPED**: the env was not loaded. Run `make -C acctest env`,
   confirm `acctest/env` exists, then `make acctest`.
 - **Env looks stale** (after re-applying a fixture, or rotated keys): delete it
@@ -64,6 +81,14 @@ make -C acctest apply-gcp     # create or update a fixture (gcp / azure / aws)
 make -C acctest destroy-gcp   # tear it down
 ```
 
+For **gcp**, `apply-gcp` and `destroy-gcp` open their own IAP tunnels (API plus
+an SSH leg for the YBA install and destroy-time `yba-ctl clean` — the VM
+accepts nothing else). This works even on a first-ever apply: the tunnel legs
+retry until the VM exists and the installer waits for SSH, so one `apply-gcp`
+bootstraps end to end. Since the fixture SA key may not exist yet, these run
+as *your* gcloud login, which needs `roles/iap.tunnelResourceAccessor` (or
+project owner) on `byoc-dev`.
+
 Each cloud has its own fixture target (`apply-gcp`/`apply-azure`/`apply-aws` and
 the matching `destroy-*`). The AWS fixture authenticates with the `byoc-dev` AWS
 profile by default (override with the `aws_profile` var); the GCP and Azure ones
@@ -78,9 +103,11 @@ against the already-installed standing YBA.
 
 ## CI
 
-CI has no cloud access. It reads the env from the `ACCTEST_ENV` GitHub Actions
-secret (written to `acctest/env`, then sourced like a local run). Publish/refresh
-that secret after re-applying a fixture:
+CI reads the env from the `ACCTEST_ENV` GitHub Actions secret (written to
+`acctest/env`, then sourced like a local run). There are no CI-specific tunnel
+steps: `make acctest` opens the IAP tunnel the same way it does locally, as the
+fixture service account inside that env. Publish/refresh the secret after
+re-applying a fixture:
 
 ```bash
 make -C acctest push-github-secrets

--- a/acctest/auth.sh
+++ b/acctest/auth.sh
@@ -14,11 +14,15 @@ AWS_PROFILE_NAME="${AWS_PROFILE:-byoc-dev}"
 echo 'Authenticating in clouds'
 
 echo "==> GCP (project: $GCP_PROJECT)"
+# print-access-token proves the login is USABLE — a listed account whose
+# session has expired under org reauth policy still shows ACTIVE in
+# `gcloud auth list` but cannot mint tokens.
 active="$(gcloud auth list --filter=status:ACTIVE --format='value(account)' 2>/dev/null | head -1 || true)"
-if printf '%s' "$active" | grep -q '@yugabyte.com'; then
+if printf '%s' "$active" | grep -q '@yugabyte.com' &&
+	gcloud auth print-access-token >/dev/null 2>&1; then
 	echo "    signed in as $active"
 else
-	echo "    no active @yugabyte.com account — opening browser login"
+	echo "    no usable @yugabyte.com login (absent or expired) — opening browser login"
 	gcloud auth login --quiet
 fi
 if [ "$(gcloud config get-value project 2>/dev/null)" != "$GCP_PROJECT" ]; then
@@ -26,8 +30,9 @@ if [ "$(gcloud config get-value project 2>/dev/null)" != "$GCP_PROJECT" ]; then
 	gcloud config set project "$GCP_PROJECT" >/dev/null
 fi
 adc_file="$HOME/.config/gcloud/application_default_credentials.json"
-if [ ! -e "$adc_file" ]; then
-	echo "    no Application Default Credentials — opening ADC login (terraform uses these)"
+if [ ! -e "$adc_file" ] ||
+	! gcloud auth application-default print-access-token >/dev/null 2>&1; then
+	echo "    no usable Application Default Credentials — opening ADC login (terraform uses these)"
 	gcloud auth application-default login
 fi
 # Align the ADC quota project with the active project (silences gcloud's

--- a/acctest/gcp/iam.tf
+++ b/acctest/gcp/iam.tf
@@ -35,6 +35,17 @@ resource "google_storage_bucket_iam_member" "backups_admin" {
   member = "serviceAccount:${google_service_account.yba.email}"
 }
 
+# Test runs (CI and local `make acctest` alike, via with-yba-tunnel.sh)
+# authenticate gcloud as this SA (its key is TF_VAR_GCP_CREDENTIALS in the env)
+# to open the IAP tunnel to the standing YBA — the only ingress path. Humans
+# need the role personally (or project owner) only for fixture apply/destroy,
+# which tunnel as the ambient gcloud login (this key may not exist yet).
+resource "google_project_iam_member" "iap_tunnel" {
+  project = var.gcp_project_id
+  role    = "roles/iap.tunnelResourceAccessor"
+  member  = "serviceAccount:${google_service_account.yba.email}"
+}
+
 # YBA provisions universe VMs and attaches itself as their runtime SA, which
 # requires yba to actAs itself.
 resource "google_service_account_iam_member" "yba_acts_as_self" {

--- a/acctest/gcp/in-vars.tf
+++ b/acctest/gcp/in-vars.tf
@@ -41,7 +41,7 @@ variable "ybdb_cidr" {
 }
 
 variable "operator_cidr_ranges" {
-  description = "CIDR ranges for operator access (SSH, YBA UI, debugging)"
+  description = "CIDR ranges allowed direct access to ephemeral install-test VMs."
   type        = list(string)
 }
 

--- a/acctest/gcp/network.tf
+++ b/acctest/gcp/network.tf
@@ -24,8 +24,11 @@ resource "google_compute_subnetwork" "ybdb" {
   ip_cidr_range = var.ybdb_cidr
 }
 
-# Firewalls, kept minimal: allow everything inside the VPC, plus operator
-# access (SSH + YBA UI/API) from var.operator_cidr_ranges.
+# Firewalls, kept minimal: allow everything inside the VPC, plus IAP TCP
+# forwarding. The standing YBA VM has no direct internet ingress — every
+# operator/CI connection (SSH + YBA UI/API) rides an IAP tunnel
+# (acctest/with-yba-tunnel.sh). Only ephemeral install-test VMs (tagged
+# yba-install-target) accept direct traffic, from var.operator_cidr_ranges.
 
 # Allow all traffic between nodes inside the VPC (YBA <-> YBDB, YBDB <-> YBDB).
 resource "google_compute_firewall" "internal" {
@@ -66,9 +69,38 @@ resource "google_compute_firewall" "yb_db_node" {
   ]
 }
 
-# Allow operator access to YBA (SSH for the installer, 443 for the UI/API).
-resource "google_compute_firewall" "operator" {
-  name    = "${var.prefix}-allow-operator"
+# IAP TCP forwarding requires the IAP API on the project.
+resource "google_project_service" "iap" {
+  project            = var.gcp_project_id
+  service            = "iap.googleapis.com"
+  disable_on_destroy = false
+}
+
+# 35.235.240.0/20 is Google's fixed IAP relay range — tunnel traffic reaches the
+# VM from it, never from the client's IP. VPC-wide is safe: IAP still requires
+# per-caller IAM (roles/iap.tunnelResourceAccessor) before it forwards anything.
+resource "google_compute_firewall" "iap" {
+  name    = "${var.prefix}-allow-iap"
+  network = google_compute_network.main.id
+
+  allow {
+    protocol = "tcp"
+    ports = [
+      "22",  # SSH (installer)
+      "443", # YBA UI/API
+    ]
+  }
+
+  source_ranges = ["35.235.240.0/20"]
+}
+
+# Direct access for ephemeral install-test VMs only (the OS-image-upgrade long
+# test SSHes to its throwaway VM from the runner; runner IPs are unstable so an
+# IAP tunnel can't be pre-arranged mid-test). The standing YBA VM is untagged
+# and stays unreachable. Tag literal also lives in the long test's config
+# (resource_yba_installer_os_upgrade_test.go).
+resource "google_compute_firewall" "install_target" {
+  name    = "${var.prefix}-allow-install-target"
   network = google_compute_network.main.id
 
   allow {
@@ -79,5 +111,6 @@ resource "google_compute_firewall" "operator" {
     ]
   }
 
+  target_tags   = ["yba-install-target"]
   source_ranges = var.operator_cidr_ranges
 }

--- a/acctest/gcp/out-vars.tf
+++ b/acctest/gcp/out-vars.tf
@@ -11,6 +11,10 @@
 # (storage-config, cloud_provider, user, customer). The prefixed
 # TF_VAR_GCP_YBA_HOST/TF_VAR_GCP_YBA_API_KEY points the GCP provider tests at
 # this same YBA, mirroring how aws/azure target their own fixture YBAs.
+#
+# Both are the tunnel-local endpoint (local.yba_api_host): the standing YBA has
+# no direct ingress. Every consumer tunnels via acctest/with-yba-tunnel.sh —
+# `make acctest` (CI and local) and the apply-gcp/destroy-gcp fixture targets.
 
 locals {
   test_env = <<-EOT
@@ -22,9 +26,9 @@ locals {
     TF_VAR_GCP_IMAGE='${data.google_compute_image.ybdb.self_link}'
     TF_VAR_GCP_YBA_VERSION='${var.yba_version}'
     TF_VAR_GCS_BACKUP_LOCATION='gs://${google_storage_bucket.backups.name}'
-    TF_VAR_GCP_YBA_HOST='${google_compute_address.yba.address}'
+    TF_VAR_GCP_YBA_HOST='${local.yba_api_host}'
     TF_VAR_GCP_YBA_API_KEY='${yba_customer_resource.customer.api_token}'
-    YBA_HOST='${google_compute_address.yba.address}'
+    YBA_HOST='${local.yba_api_host}'
     YBA_API_KEY='${yba_customer_resource.customer.api_token}'
   EOT
 }
@@ -37,7 +41,8 @@ output "test_env" {
 }
 
 output "yba_url" {
-  value = "https://${google_compute_address.yba.address}"
+  description = "YBA UI/API endpoint; reachable only while an IAP tunnel is up (acctest/with-yba-tunnel.sh)."
+  value       = "https://${local.yba_api_host}"
 }
 
 output "yba_username" {

--- a/acctest/gcp/providers.tf
+++ b/acctest/gcp/providers.tf
@@ -46,11 +46,12 @@ provider "google" {
 }
 
 # Bootstrap provider for the install/first-customer flow: it points at the YBA
-# VM's address but carries no api_token (the provider runs unauthenticated until
-# yba_customer_resource registers the first user and mints the token). The
-# installer ignores host (it works over SSH); the customer resource needs it to
-# reach the freshly-installed YBA instead of the default localhost:9000.
+# API's tunnel-local endpoint but carries no api_token (the provider runs
+# unauthenticated until yba_customer_resource registers the first user and
+# mints the token). The installer ignores host (it works over SSH); the
+# customer resource needs it to reach the freshly-installed YBA instead of the
+# default localhost:9000.
 provider "yba" {
   alias = "bootstrap"
-  host  = google_compute_address.yba.address
+  host  = local.yba_api_host
 }

--- a/acctest/gcp/terraform.tfvars
+++ b/acctest/gcp/terraform.tfvars
@@ -14,7 +14,10 @@ yba_version = "2.31.0.0-b164"
 yba_cidr  = "10.0.1.0/24"
 ybdb_cidr = "10.0.2.0/24"
 
-# Open for now to keep CI simple; tighten to the runner's IP later.
+# Reaches only VMs tagged yba-install-target — the throwaway VMs the
+# OS-image-upgrade long test creates and SSHes into from GitHub runners, whose
+# IPs are unstable (hence world-open). The standing YBA VM is untagged: no
+# direct ingress, IAP tunnel only.
 operator_cidr_ranges = ["0.0.0.0/0"]
 
 labels = {

--- a/acctest/gcp/yba.tf
+++ b/acctest/gcp/yba.tf
@@ -7,7 +7,13 @@
 # `make acctest` just consumes it. Tear down with the base.
 
 locals {
-  yba_ssh_host = google_compute_address.yba.address
+  # The YBA VM has no direct ingress; every connection (this install, the
+  # bootstrap provider, tests) rides an IAP tunnel at fixed local ports —
+  # acctest/with-yba-tunnel.sh maps 9443 -> VM:443 and (with -s, used by the
+  # apply-gcp/destroy-gcp targets) 2222 -> VM:22.
+  yba_ssh_host = "127.0.0.1"
+  yba_ssh_port = 2222
+  yba_api_host = "127.0.0.1:9443"
 }
 
 # Dedicated SSH keypair for the standing YBA VM, generated once and kept in the
@@ -105,6 +111,7 @@ resource "yba_installer" "install" {
   provider = yba.bootstrap
 
   ssh_host_ip               = local.yba_ssh_host
+  ssh_port                  = local.yba_ssh_port
   ssh_user                  = "yugabyte"
   ssh_private_key           = tls_private_key.yba.private_key_openssh
   yba_license_file          = "${path.module}/../../yugabyte_anywhere.lic"
@@ -113,10 +120,30 @@ resource "yba_installer" "install" {
   host_os                   = "linux"
   host_architecture         = "x86_64"
 
-  # The instance is an implicit dependency (via ssh_host_ip), but the firewall
-  # that opens SSH/443 is not — without this the installer can start before
-  # the rule exists and fail to connect.
-  depends_on = [google_compute_firewall.operator]
+  # ssh_host_ip is tunnel-local, so nothing here implicitly depends on the
+  # instance or the IAP path — without these the installer can start dialing
+  # before the VM/firewall/API exist and the tunnel has nothing to reach.
+  depends_on = [
+    google_compute_instance.yba,
+    google_compute_firewall.iap,
+    google_project_service.iap,
+  ]
+}
+
+# The tunnel's 443 leg crash-loops while YBA is still installing (gcloud only
+# opens its local listener after its backend connection test passes), so for
+# up to ~15s after yba-ctl finishes nothing listens on the local port. The
+# provider's API connection is one-shot — without this wait a fresh bootstrap
+# fails at the customer step. Curling through the leg also forces it to
+# establish.
+resource "terraform_data" "wait_for_yba_api" {
+  triggers_replace = yba_installer.install.id
+
+  provisioner "local-exec" {
+    command = "for i in $(seq 1 60); do curl -sk -o /dev/null https://${local.yba_api_host}/ && exit 0; sleep 5; done; echo 'YBA API never answered on ${local.yba_api_host}' >&2; exit 1"
+  }
+
+  depends_on = [yba_installer.install]
 }
 
 # Register the initial superuser; exposes the API token (published as YBA_API_KEY).
@@ -132,5 +159,5 @@ resource "yba_customer_resource" "customer" {
     ignore_changes = [password]
   }
 
-  depends_on = [yba_installer.install]
+  depends_on = [terraform_data.wait_for_yba_api]
 }

--- a/acctest/with-yba-tunnel.sh
+++ b/acctest/with-yba-tunnel.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# Copyright 2026 YugabyteDB, Inc.
+# SPDX-License-Identifier: MPL-2.0
+#
+# with-yba-tunnel.sh [-s] <command...> — run <command> with an IAP tunnel to
+# the standing YBA up (127.0.0.1:9443 -> VM:443; the VM accepts no direct
+# ingress). The single owner of the tunnel constants and logic:
+#
+#   - `make acctest` / `make acctest-long` (CI and local, identically): opens
+#     the API tunnel, waits for it, runs the tests, tears down.
+#   - `make -C acctest apply-gcp` / `destroy-gcp` pass -s, which adds
+#     127.0.0.1:2222 -> VM:22 (the yba_installer's SSH). Ops on an existing
+#     stand hit the YBA API within seconds (terraform configures the bootstrap
+#     provider during refresh, a one-shot connection), so -s still waits for
+#     the API leg — but bounded, warning and proceeding on timeout: on a
+#     first-ever apply nothing can answer until terraform has created the VM
+#     and installed YBA, and that flow only reaches the API after the install.
+#
+# Auth: the fixture service account when TF_VAR_GCP_CREDENTIALS is set (test
+# runs source acctest/env), inside an isolated CLOUDSDK_CONFIG so the caller's
+# gcloud config and active account are never touched and no personal IAP grant
+# is needed. Otherwise the ambient gcloud login (fixture ops, where the SA key
+# may not exist yet), which needs roles/iap.tunnelResourceAccessor or owner.
+#
+# Each leg retries in a loop: survives IAP disconnects mid-run and comes up on
+# its own once its target exists. If 127.0.0.1:9443 already answers, the test
+# path execs straight through; duplicate legs elsewhere just fail to bind and
+# idle harmlessly in their loop.
+set -eu
+
+# Constants match acctest/gcp/terraform.tfvars (prefix, gcp_project_id,
+# gcp_region + "-a").
+VM=tf-acctest-yba
+PROJECT=byoc-dev
+ZONE=us-west1-a
+
+ssh_leg=
+if [ "${1:-}" = "-s" ]; then
+  ssh_leg=1
+  shift
+fi
+
+ready() { curl -sk -o /dev/null --max-time 2 https://127.0.0.1:9443/; }
+
+if [ -z "$ssh_leg" ] && ready; then
+  exec "$@"
+fi
+
+umask 077
+tmp=$(mktemp -d)
+loop_pids=
+cleanup() {
+  # Kill each retry loop first (stops respawning), then the gcloud it recorded.
+  for p in $loop_pids; do kill "$p" 2>/dev/null || true; done
+  for f in "$tmp"/leg-*.pid; do
+    [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true
+  done
+  rm -rf "$tmp"
+}
+trap cleanup EXIT
+trap 'exit 130' INT TERM
+
+if [ -n "${TF_VAR_GCP_CREDENTIALS:-}" ]; then
+  export CLOUDSDK_CONFIG="$tmp/gcloud"
+  printf '%s' "$TF_VAR_GCP_CREDENTIALS" >"$tmp/sa.json"
+  gcloud auth activate-service-account --key-file="$tmp/sa.json" --quiet
+elif ! gcloud auth print-access-token >/dev/null 2>&1; then
+  # Ambient path: fail fast with a remedy — an expired login otherwise
+  # surfaces later as an opaque connection-refused from the tunnel.
+  echo "with-yba-tunnel: no usable gcloud login - run: make -C acctest auth" >&2
+  exit 1
+fi
+
+leg() { # leg <vm-port> <local-port>
+  ( while :; do
+      gcloud compute start-iap-tunnel "$VM" "$1" \
+        --project="$PROJECT" --zone="$ZONE" \
+        --local-host-port=localhost:"$2" >>"$tmp/leg-$1.log" 2>&1 &
+      echo $! >"$tmp/leg-$1.pid"
+      wait $! || true
+      sleep 5
+    done ) &
+  loop_pids="$loop_pids $!"
+}
+
+leg 443 9443
+if [ -n "$ssh_leg" ]; then
+  leg 22 2222
+  for _ in $(seq 1 12); do
+    if ready; then break; fi
+    sleep 5
+  done
+  if ! ready; then
+    echo "with-yba-tunnel: 127.0.0.1:9443 not answering (fresh bootstrap?); proceeding" >&2
+  fi
+  rc=0
+  "$@" || rc=$?
+  if [ "$rc" -ne 0 ]; then
+    echo "with-yba-tunnel: command failed (rc=$rc); tunnel logs:" >&2
+    cat "$tmp"/leg-*.log >&2 || true
+  fi
+  exit "$rc"
+fi
+
+for _ in $(seq 1 30); do
+  if ready; then
+    "$@"
+    exit $?
+  fi
+  sleep 2
+done
+
+echo "IAP tunnel to the standing YBA did not become ready:" >&2
+cat "$tmp"/leg-*.log >&2
+exit 1

--- a/docs/guides/managing-private-yba-over-ssh-tunnel.md
+++ b/docs/guides/managing-private-yba-over-ssh-tunnel.md
@@ -1,0 +1,206 @@
+---
+subcategory: ""
+page_title: "Managing a private YBA over an SSH tunnel"
+description: |-
+  Using the Terraform provider against a YugabyteDB Anywhere host with no reachable API endpoint, via a local port-forward
+---
+
+# Managing a private YBA over an SSH tunnel
+
+Many YugabyteDB Anywhere (YBA) installations run inside a private VPC or a
+locked-down network where the API port is not reachable from the machine
+that runs Terraform. The provider itself only needs an HTTPS (or HTTP)
+endpoint it can connect to - it has no notion of SSH or tunnels. If you can
+SSH to the YBA VM, an SSH local port-forward is all it takes: the forward
+opens a listener on the Terraform runner, and the provider talks to that
+listener as if it were YBA.
+
+The tunnel is entirely out-of-band. You start it yourself, outside of
+Terraform, before running `terraform plan` / `apply` / `destroy`, and keep it
+open for the duration of the run. The provider configuration has no
+tunnel-specific fields - it just points `host` at the local address the
+tunnel is listening on.
+
+Two machines are involved throughout this page:
+
+- **Terraform runner** - the machine that executes `terraform` (your
+  workstation or a CI runner). The tunnel command runs *here*, and the
+  forwarded ports open *here*.
+- **YBA VM** - the private host running (or about to run) YBA. It is the
+  SSH destination; nothing on it needs to change.
+
+## How the YBA API becomes reachable
+
+The examples on this page forward two ports:
+
+| Listens on (Terraform runner) | Forwards to (YBA VM) | Used by |
+| --- | --- | --- |
+| `127.0.0.1:9443` | `443` - the YBA API | The provider (`host`) |
+| `127.0.0.1:2222` | `22` - the VM's `sshd` | `yba_installer` only |
+
+While the tunnel is up, the YBA API - normally `https://<yba-vm>:443` inside
+the private network - is reachable from the Terraform runner as
+`https://127.0.0.1:9443`. The second forward is only needed if you use
+`yba_installer` to install or manage YBA on the node over SSH; skip it when
+managing an already-installed YBA.
+
+The local ports `9443` and `2222` are arbitrary conventions used throughout
+this page - any free local ports work.
+
+## Start the tunnel
+
+On the **Terraform runner**, run:
+
+```sh
+ssh -N -L 9443:localhost:443 -L 2222:localhost:22 user@yba-vm
+```
+
+Breaking that down:
+
+| Part | Side | Meaning |
+| --- | --- | --- |
+| `user@yba-vm` | YBA VM | The SSH login on the YBA VM. |
+| `-L 9443:localhost:443` | both | Listen on port `9443` on the Terraform runner; forward connections to port `443` on the YBA VM. |
+| `-L 2222:localhost:22` | both | Listen on port `2222` on the Terraform runner; forward to the YBA VM's own `sshd` on `22`. Only needed for `yba_installer`. |
+| `-N` | - | Do not run a remote command - tunnel only. |
+
+In each `-L local:host:port` forward, the *first* port is opened on the
+Terraform runner, and `host:port` is resolved *from the YBA VM's
+perspective* - `localhost:443` means port 443 on the YBA VM itself, not on
+your machine.
+
+Verify the API is reachable before running Terraform:
+
+```sh
+curl -k https://127.0.0.1:9443
+```
+
+Keep the `ssh` process running for as long as you need Terraform to talk to
+YBA - closing the tunnel mid-`apply` fails the in-flight API calls the same
+way any other network interruption would.
+
+~> **Note:** If the Terraform runner cannot SSH to the YBA VM directly, hop
+through a reachable host with `-J user@jump-host`, or SSH to that host and
+replace `localhost` in the forwards with the YBA VM's private address as
+seen from there. The command still runs on the Terraform runner, and the
+provider configuration below is unchanged. The same applies to cloud-native
+port-forwarding tools (`gcloud compute ssh -- -L ...`, AWS SSM port
+forwarding, `az network bastion tunnel`): anything that produces a local
+TCP listener on the Terraform runner works identically.
+
+## Point the provider at the tunnel
+
+The provider's `host` argument takes an IP address or domain name with port,
+no scheme:
+
+```terraform
+provider "yba" {
+  host      = "127.0.0.1:9443"
+  api_token = var.yba_api_token
+}
+```
+
+Since the tunnel's listener is on the Terraform runner, `host` is always
+`127.0.0.1` (or `localhost`) plus the local port you chose - `9443` in these
+examples - regardless of where the YBA VM actually lives.
+
+## TLS behavior over the tunnel
+
+~> **Note:** The provider does not validate the YBA server's TLS
+certificate (neither the chain nor the hostname) under any circumstances,
+tunneled or not. A connection to `127.0.0.1:9443` therefore succeeds even though the
+certificate YBA presents was issued for a different hostname; there is
+nothing to enable or work around for the tunnel scenario specifically.
+Practically, this means the SSH tunnel itself is what authenticates and
+encrypts the hop to the VM - treat the tunnel, not the HTTPS layer on top of
+it, as the real security boundary.
+
+## Installing YBA through the same tunnel
+
+`yba_installer` drives the install over SSH, so point its SSH fields at the
+forwarded `sshd` port on the Terraform runner instead of the VM's real
+address:
+
+```terraform
+resource "yba_installer" "install" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "127.0.0.1"
+  ssh_port    = 2222
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key = var.ssh_private_key
+  yba_version     = "<yba-version-with-build-number>"
+}
+```
+
+`ssh_port` is optional and defaults to `22`; set it only when, as here,
+`sshd` is reachable through a forwarded port rather than directly on `22`.
+
+~> **Note:** `yba_installer` downloads the YBA install bundle *on the node
+itself* - the install commands run over the SSH session and include a
+`curl -O` against `downloads.yugabyte.com` (or `releases.yugabyte.com` for
+pre-release/CI builds), not against your workstation. The tunnel only needs
+to carry the SSH session; the YBA VM needs its own outbound network path to
+`downloads.yugabyte.com` / `releases.yugabyte.com` to complete the install.
+
+## Complete example
+
+Putting it together: start the tunnel on the Terraform runner, then apply a
+configuration that installs YBA over the forwarded `sshd`, creates the
+initial customer through an unauthenticated provider, and is ready for
+further resources through an authenticated one.
+
+```sh
+ssh -N -L 9443:localhost:443 -L 2222:localhost:22 user@yba-vm
+```
+
+```terraform
+terraform {
+  required_providers {
+    yba = {
+      source  = "yugabyte/yba"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "yba" {
+  alias = "unauthenticated"
+  host  = "127.0.0.1:9443"
+}
+
+resource "yba_installer" "install" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "127.0.0.1"
+  ssh_port    = 2222
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key = var.ssh_private_key
+  yba_version     = "<yba-version-with-build-number>"
+}
+
+variable "customer_password" {
+  type      = string
+  sensitive = true
+}
+
+resource "yba_customer_resource" "customer" {
+  provider   = yba.unauthenticated
+  depends_on = [yba_installer.install]
+  code       = "admin"
+  email      = "<email>"
+  name       = "<customer-name>"
+  password   = var.customer_password
+}
+
+provider "yba" {
+  host      = "127.0.0.1:9443"
+  api_token = yba_customer_resource.customer.api_token
+}
+```
+
+Once the customer resource is created, switch subsequent resources
+(providers, universes, storage configs, and so on) to the authenticated
+`yba` provider, same as any other YBA installation. See
+[Running Terraform on existing YugabyteDB Anywhere installations](running-terraform-on-existing-yba-installations)
+for that hand-off in more detail.

--- a/docs/resources/installer.md
+++ b/docs/resources/installer.md
@@ -34,6 +34,7 @@ provider "yba" {
 resource "yba_installer" "install" {
   provider    = yba.unauthenticated
   ssh_host_ip = "<ip-of-yba-node-for-ssh-commands>"
+  ssh_port    = 22
   ssh_user    = "<ssh-user>"
 
   ssh_private_key      = var.ssh_private_key
@@ -55,6 +56,24 @@ resource "yba_installer" "install_from_files" {
   yba_license_file          = "<path-to-yba-license.lic-file>"
   application_settings_file = "<path-to-application_settings.conf-file>"
   yba_version               = "<YugabyteDB Anywhere-version-with-build-number>"
+}
+
+# ssh_host_ip and ssh_port are simply the address the installer dials - any
+# reachable sshd works. Set ssh_port when that address uses a non-default
+# port: an sshd listening on 2222, a NAT/firewall mapping, or the local end
+# of a tunnel (e.g. `ssh -L 2222:<yba-node>:22 <jump-host>` with
+# ssh_host_ip = "127.0.0.1").
+resource "yba_installer" "install_non_default_port" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "<address-where-sshd-is-reachable>"
+  ssh_port    = 2222
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key      = var.ssh_private_key
+  yba_license          = var.yba_license_content
+  application_settings = local.yba_ctl_yaml
+
+  yba_version = "<YugabyteDB Anywhere-version-with-build-number>"
 }
 ```
 
@@ -97,6 +116,7 @@ For further details on configuration and host requirements, refer to [Install YB
 - `host_os` (String) Operating System of the host Virtual Machine. Default is linux.
 - `reconfigure` (Boolean) Force a reconfiguration on the next apply, even when no other tracked attribute has changed. Content changes to `application_settings`, `tls_certificate`, or `tls_key` already trigger reconfiguration automatically.
 - `skip_preflight_checks` (List of String) Check names to be skipped during preflight check.
+- `ssh_port` (Number) TCP port used for SSH and SCP connections to the host. Defaults to 22. Set this when sshd is reachable on a different port at `ssh_host_ip` - for example a non-standard sshd port, a NAT or firewall port mapping, or the local end of an SSH tunnel.
 - `ssh_private_key` (String, Sensitive) Contents of the private key to use for ssh commands. Use this instead of `ssh_private_key_file_path` to pass the key directly without writing it to a local file.
 - `ssh_private_key_file_path` (String) Path to file containing the private key to use for ssh commands. Conflicts with `ssh_private_key`.
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))

--- a/examples/resources/yba_installer/resource.tf
+++ b/examples/resources/yba_installer/resource.tf
@@ -8,6 +8,7 @@ provider "yba" {
 resource "yba_installer" "install" {
   provider    = yba.unauthenticated
   ssh_host_ip = "<ip-of-yba-node-for-ssh-commands>"
+  ssh_port    = 22
   ssh_user    = "<ssh-user>"
 
   ssh_private_key      = var.ssh_private_key
@@ -29,4 +30,22 @@ resource "yba_installer" "install_from_files" {
   yba_license_file          = "<path-to-yba-license.lic-file>"
   application_settings_file = "<path-to-application_settings.conf-file>"
   yba_version               = "<YugabyteDB Anywhere-version-with-build-number>"
+}
+
+# ssh_host_ip and ssh_port are simply the address the installer dials - any
+# reachable sshd works. Set ssh_port when that address uses a non-default
+# port: an sshd listening on 2222, a NAT/firewall mapping, or the local end
+# of a tunnel (e.g. `ssh -L 2222:<yba-node>:22 <jump-host>` with
+# ssh_host_ip = "127.0.0.1").
+resource "yba_installer" "install_non_default_port" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "<address-where-sshd-is-reachable>"
+  ssh_port    = 2222
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key      = var.ssh_private_key
+  yba_license          = var.yba_license_content
+  application_settings = local.yba_ctl_yaml
+
+  yba_version = "<YugabyteDB Anywhere-version-with-build-number>"
 }

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -74,6 +74,9 @@ var (
 	// APIClient is the shared YBA client (YBA_HOST), used by storage-config,
 	// user, and customer tests. Provider tests use APIClientForCloud instead.
 	APIClient *api.APIClient
+	// sharedClientErr records why APIClient could not be built; surfaced by
+	// TestAccPreCheck so only shared-YBA tests fail, not every package.
+	sharedClientErr error
 
 	// cloudClients caches one YBA client per cloud, keyed by cloud code.
 	cloudClients   = map[string]*api.APIClient{}
@@ -119,7 +122,8 @@ func APIClientForCloud(cloud string) (*api.APIClient, error) {
 	}
 	c, err := api.NewAPIClient(true, CloudYBAHost(cloud), CloudYBAAPIKey(cloud))
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("%s fixture YBA (TF_VAR_%s_YBA_HOST=%s) is unreachable: %w",
+			cloud, cloud, CloudYBAHost(cloud), err)
 	}
 	cloudClients[cloud] = c
 	return c, nil
@@ -212,14 +216,18 @@ func init() {
 	}
 	// Build the shared client only when a shared YBA is set, so importing this
 	// package never panics on an empty YBA_HOST. Tests that use the shared client
-	// gate on TestAccPreCheck (which fails fast on an empty host), so they never
-	// hit a nil client.
+	// gate on TestAccPreCheck (which fails fast on an empty host or a dead
+	// client), so they never hit a nil client.
 	if TestHost() == "" {
 		return
 	}
 	c, err := api.NewAPIClient(true, TestHost(), TestAPIKey())
 	if err != nil {
-		panic(err)
+		// Never panic here: that kills every test binary importing this
+		// package, including per-cloud provider tests that talk only to their
+		// own YBA (TF_VAR_<CLOUD>_YBA_HOST) and never touch the shared one.
+		sharedClientErr = err
+		return
 	}
 	APIClient = c
 }
@@ -343,6 +351,10 @@ func TestAccPreCheck(t *testing.T) {
 	}
 	if TestAPIKey() == "" {
 		t.Fatal("YBA_API_KEY or YB_API_KEY must be set for acceptance tests")
+	}
+	if sharedClientErr != nil {
+		t.Fatalf("shared YBA (YBA_HOST=%s) is unreachable%s: %v",
+			TestHost(), sharedClientErr)
 	}
 }
 

--- a/internal/acctest/acctest.go
+++ b/internal/acctest/acctest.go
@@ -353,7 +353,7 @@ func TestAccPreCheck(t *testing.T) {
 		t.Fatal("YBA_API_KEY or YB_API_KEY must be set for acceptance tests")
 	}
 	if sharedClientErr != nil {
-		t.Fatalf("shared YBA (YBA_HOST=%s) is unreachable%s: %v",
+		t.Fatalf("shared YBA (YBA_HOST=%s) is unreachable: %v",
 			TestHost(), sharedClientErr)
 	}
 }

--- a/internal/installation/resource_yba_installer.go
+++ b/internal/installation/resource_yba_installer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/yugabyte/terraform-provider-yba/internal/utils"
@@ -253,6 +254,16 @@ func ResourceYBAInstaller() *schema.Resource {
 				Required: true,
 				Description: "IP address of VM for SSH. Typically same as public_ip or " +
 					"private_ip.",
+			},
+			"ssh_port": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      22,
+				ValidateFunc: validation.IntBetween(1, 65535),
+				Description: "TCP port used for SSH and SCP connections to the host. " +
+					"Defaults to 22. Set this when sshd is reachable on a different port " +
+					"at `ssh_host_ip` - for example a non-standard sshd port, a NAT or " +
+					"firewall port mapping, or the local end of an SSH tunnel.",
 			},
 			"ssh_private_key_file_path": {
 				Type:     schema.TypeString,
@@ -493,12 +504,20 @@ func resourceYBAInstallerCreate(
 
 	hostIPForSSH := d.Get("ssh_host_ip").(string)
 	user := d.Get("ssh_user").(string)
+	sshPort := d.Get("ssh_port").(int)
 	pk, err := resolveSSHPrivateKey(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	sshClient, err := waitForIP(ctx, user, hostIPForSSH, pk, d.Timeout(schema.TimeoutCreate))
+	sshClient, err := waitForIP(
+		ctx,
+		user,
+		hostIPForSSH,
+		sshPort,
+		pk,
+		d.Timeout(schema.TimeoutCreate),
+	)
 	if err != nil {
 		tflog.Error(ctx, "Timeout: Couldn't connect to YugabyteDB Anywhere host")
 		return diag.FromErr(err)
@@ -558,12 +577,20 @@ func resourceYBAInstallerUpdate(
 
 	hostIPForSSH := d.Get("ssh_host_ip").(string)
 	user := d.Get("ssh_user").(string)
+	sshPort := d.Get("ssh_port").(int)
 	pk, err := resolveSSHPrivateKey(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 	skipPreflightChecksList := utils.StringSlice(d.Get("skip_preflight_checks").([]interface{}))
-	sshClient, err := waitForIP(ctx, user, hostIPForSSH, pk, d.Timeout(schema.TimeoutCreate))
+	sshClient, err := waitForIP(
+		ctx,
+		user,
+		hostIPForSSH,
+		sshPort,
+		pk,
+		d.Timeout(schema.TimeoutCreate),
+	)
 	if err != nil {
 		tflog.Error(ctx, "Timeout: Couldn't connect to YugabyteDB Anywhere host")
 		return diag.FromErr(err)
@@ -638,12 +665,13 @@ func resourceYBAInstallerDelete(
 
 	hostIPForSSH := d.Get("ssh_host_ip").(string)
 	user := d.Get("ssh_user").(string)
+	sshPort := d.Get("ssh_port").(int)
 	pk, err := resolveSSHPrivateKey(d)
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	sshClient, err := connectSSHForDelete(ctx, user, hostIPForSSH, pk)
+	sshClient, err := connectSSHForDelete(ctx, user, hostIPForSSH, sshPort, pk)
 	if err != nil {
 		if errors.Is(err, errSSHHostUnreachable) {
 			// Host never answered TCP within the retry budget: it's already gone

--- a/internal/installation/resource_yba_installer_os_upgrade_test.go
+++ b/internal/installation/resource_yba_installer_os_upgrade_test.go
@@ -337,6 +337,10 @@ resource "google_compute_instance" "yba" {
   machine_type = "n2-standard-4"
   zone         = "${var.GCP_REGION}-a"
 
+  # Opts into the fixture's direct-ingress firewall rule (the standing YBA VM
+  # is untagged and IAP-only): this test SSHes here straight from the runner.
+  tags = ["yba-install-target"]
+
   allow_stopping_for_update = true
 
   # Changing this image replaces the VM (GCP can't reimage a boot disk in

--- a/internal/installation/resource_yba_installer_test.go
+++ b/internal/installation/resource_yba_installer_test.go
@@ -41,6 +41,58 @@ func TestSchemaIsValid(t *testing.T) {
 	}
 }
 
+// TestSSHPortSchema guards the ssh_port contract: optional with default 22
+// (existing configs keep dialing 22), port-range validated, not ForceNew.
+func TestSSHPortSchema(t *testing.T) {
+	s, ok := ResourceYBAInstaller().Schema["ssh_port"]
+	if !ok {
+		t.Fatal("expected ssh_port attribute in schema")
+	}
+	if s.Type != schema.TypeInt {
+		t.Errorf("ssh_port type = %v, want TypeInt", s.Type)
+	}
+	if !s.Optional {
+		t.Error("ssh_port should be Optional")
+	}
+	if s.Required {
+		t.Error("ssh_port should not be Required")
+	}
+	if s.ForceNew {
+		t.Error("ssh_port should not be ForceNew: it's connection metadata like " +
+			"ssh_host_ip/ssh_user, which also don't force recreation")
+	}
+	if s.Default != 22 {
+		t.Errorf("ssh_port default = %v, want 22", s.Default)
+	}
+	if s.ValidateFunc == nil {
+		t.Fatal("expected ssh_port to have a ValidateFunc")
+	}
+
+	tests := []struct {
+		name    string
+		value   int
+		wantErr bool
+	}{
+		{"minimum valid port", 1, false},
+		{"maximum valid port", 65535, false},
+		{"default port", 22, false},
+		{"zero is invalid", 0, true},
+		{"above range is invalid", 65536, true},
+		{"negative is invalid", -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, errs := s.ValidateFunc(tt.value, "ssh_port")
+			if tt.wantErr && len(errs) == 0 {
+				t.Errorf("value %d: expected validation error, got none", tt.value)
+			}
+			if !tt.wantErr && len(errs) != 0 {
+				t.Errorf("value %d: unexpected validation errors: %v", tt.value, errs)
+			}
+		})
+	}
+}
+
 // TestResolveInstallerInput covers the inline-vs-file precedence and the
 // "neither set" case for the content/file pair.
 func TestResolveInstallerInput(t *testing.T) {

--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -149,8 +149,7 @@ func waitForIP(ctx context.Context, user string, ip string, port int, pk string,
 			tflog.Info(ctx, fmt.Sprintf("Trying SSH connection to host using ip: %s", ip))
 			c, cErr := newSSHClient(user, ip, port, pk)
 			if cErr != nil {
-				// keep polling — the host may still be coming up
-				return nil, "Waiting", nil //nolint:nilerr // intentional: error means "not ready yet"
+				return struct{}{}, "Waiting", nil //nolint:nilerr // intentional: error means "not ready yet"
 			}
 
 			return c, "Ready", nil

--- a/internal/installation/utils_installation.go
+++ b/internal/installation/utils_installation.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strconv"
 	"strings"
 	"time"
 
@@ -30,7 +31,12 @@ import (
 	"golang.org/x/crypto/ssh"
 )
 
-func newSSHClient(user string, ip string, key string) (*ssh.Client, error) {
+// sshAddr joins host and ssh_port for every SSH/SCP dial — new dial sites must use it.
+func sshAddr(ip string, port int) string {
+	return net.JoinHostPort(ip, strconv.Itoa(port))
+}
+
+func newSSHClient(user string, ip string, port int, key string) (*ssh.Client, error) {
 	pk, err := ssh.ParsePrivateKey([]byte(key))
 	if err != nil {
 		return nil, err
@@ -42,7 +48,7 @@ func newSSHClient(user string, ip string, key string) (*ssh.Client, error) {
 			ssh.PublicKeys(pk),
 		},
 	}
-	c, err := ssh.Dial("tcp", net.JoinHostPort(ip, "22"), config)
+	c, err := ssh.Dial("tcp", sshAddr(ip, port), config)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +71,8 @@ var errSSHHostUnreachable = errors.New("ssh host unreachable after retries")
 // sshConnectBudget. Outcomes: (client, nil) host answered, caller must Close;
 // (nil, errSSHHostUnreachable) host gone, nothing to clean up remotely;
 // (nil, other) bad key or handshake/auth failure — host is alive, fail loudly.
-func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client, error) {
+func connectSSHForDelete(ctx context.Context, user, ip string, port int, key string) (
+	*ssh.Client, error) {
 	signer, err := ssh.ParsePrivateKey([]byte(key))
 	if err != nil {
 		return nil, err
@@ -76,7 +83,7 @@ func connectSSHForDelete(ctx context.Context, user, ip, key string) (*ssh.Client
 		Auth:            []ssh.AuthMethod{ssh.PublicKeys(signer)},
 		Timeout:         sshDialTimeout,
 	}
-	addr := net.JoinHostPort(ip, "22")
+	addr := sshAddr(ip, port)
 
 	budgetCtx, cancel := context.WithTimeout(ctx, sshConnectBudget)
 	defer cancel()
@@ -130,8 +137,8 @@ func runCommand(ctx context.Context, client *ssh.Client, cmd string) (string, er
 	return c.String(), err
 }
 
-func waitForIP(ctx context.Context, user string, ip string, pk string, timeout time.Duration) (
-	*ssh.Client, error) {
+func waitForIP(ctx context.Context, user string, ip string, port int, pk string,
+	timeout time.Duration) (*ssh.Client, error) {
 	wait := &retry.StateChangeConf{
 		Delay:   1 * time.Second,
 		Pending: []string{"Waiting"},
@@ -140,7 +147,7 @@ func waitForIP(ctx context.Context, user string, ip string, pk string, timeout t
 
 		Refresh: func() (result interface{}, state string, err error) {
 			tflog.Info(ctx, fmt.Sprintf("Trying SSH connection to host using ip: %s", ip))
-			c, cErr := newSSHClient(user, ip, pk)
+			c, cErr := newSSHClient(user, ip, port, pk)
 			if cErr != nil {
 				// keep polling — the host may still be coming up
 				return nil, "Waiting", nil //nolint:nilerr // intentional: error means "not ready yet"

--- a/internal/installation/utils_installation_test.go
+++ b/internal/installation/utils_installation_test.go
@@ -1,0 +1,41 @@
+// Licensed to YugabyteDB, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Mozilla License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://mozilla.org/MPL/2.0/.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package installation
+
+import "testing"
+
+// TestSSHAddr guards the dial-address join every SSH/SCP connection uses:
+// non-default ports honored, IPv6 literals bracketed.
+func TestSSHAddr(t *testing.T) {
+	tests := []struct {
+		name string
+		ip   string
+		port int
+		want string
+	}{
+		{"default ssh port", "192.168.1.10", 22, "192.168.1.10:22"},
+		{"port-forwarded local address", "127.0.0.1", 2222, "127.0.0.1:2222"},
+		{"hostname", "yba.example.com", 22, "yba.example.com:22"},
+		{"ipv6 literal is bracketed", "::1", 2222, "[::1]:2222"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sshAddr(tt.ip, tt.port); got != tt.want {
+				t.Errorf("sshAddr(%q, %d) = %q, want %q", tt.ip, tt.port, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/runtimeconfig/common_test.go
+++ b/internal/runtimeconfig/common_test.go
@@ -21,6 +21,7 @@ package runtimeconfig_test
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -28,6 +29,23 @@ import (
 	"github.com/yugabyte/terraform-provider-yba/internal/acctest"
 	"github.com/yugabyte/terraform-provider-yba/internal/utils"
 )
+
+// YBA invalidates its runtime-config cache asynchronously, so a read right
+// after a write/delete can be stale — observed as a CI flake where the destroy
+// check saw the old value while YBA was under universe-task load. Poll briefly
+// before failing.
+const runtimeConfigSettle = 30 * time.Second
+
+func retryRuntimeConfigCheck(check func() error) error {
+	deadline := time.Now().Add(runtimeConfigSettle)
+	for {
+		err := check()
+		if err == nil || time.Now().After(deadline) {
+			return err
+		}
+		time.Sleep(2 * time.Second)
+	}
+}
 
 // globalScope is the well-known UUID YBA uses for global-scope runtime config.
 const globalScope = "00000000-0000-0000-0000-000000000000"
@@ -74,20 +92,22 @@ var boolCase = runtimeConfigCase{
 // runtime config key, reading it back through the API independently of state.
 func testAccCheckRuntimeConfigValue(scope, key, expected string) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
-		c := acctest.APIClient.YugawareClient
-		cUUID := acctest.APIClient.CustomerID
+		return retryRuntimeConfigCheck(func() error {
+			c := acctest.APIClient.YugawareClient
+			cUUID := acctest.APIClient.CustomerID
 
-		value, response, err := c.RuntimeConfigurationAPI.
-			GetConfigurationKey(context.Background(), cUUID, scope, key).Execute()
-		if err != nil {
-			return utils.ErrorFromHTTPResponse(response, err, utils.TestEntity,
-				"Runtime Config", "Read")
-		}
-		if value != expected {
-			return fmt.Errorf("runtime config key %q in scope %q = %q, want %q",
-				key, scope, value, expected)
-		}
-		return nil
+			value, response, err := c.RuntimeConfigurationAPI.
+				GetConfigurationKey(context.Background(), cUUID, scope, key).Execute()
+			if err != nil {
+				return utils.ErrorFromHTTPResponse(response, err, utils.TestEntity,
+					"Runtime Config", "Read")
+			}
+			if value != expected {
+				return fmt.Errorf("runtime config key %q in scope %q = %q, want %q",
+					key, scope, value, expected)
+			}
+			return nil
+		})
 	}
 }
 
@@ -97,23 +117,25 @@ func testAccCheckRuntimeConfigValue(scope, key, expected string) resource.TestCh
 // post-destroy state.
 func testAccCheckRuntimeConfigValueAbsent(scope, key, testValue string) resource.TestCheckFunc {
 	return func(_ *terraform.State) error {
-		c := acctest.APIClient.YugawareClient
-		cUUID := acctest.APIClient.CustomerID
+		return retryRuntimeConfigCheck(func() error {
+			c := acctest.APIClient.YugawareClient
+			cUUID := acctest.APIClient.CustomerID
 
-		value, response, err := c.RuntimeConfigurationAPI.
-			GetConfigurationKey(context.Background(), cUUID, scope, key).Execute()
-		if err != nil {
-			if acctest.IsResourceNotFoundError(err) {
-				return nil
+			value, response, err := c.RuntimeConfigurationAPI.
+				GetConfigurationKey(context.Background(), cUUID, scope, key).Execute()
+			if err != nil {
+				if acctest.IsResourceNotFoundError(err) {
+					return nil
+				}
+				return utils.ErrorFromHTTPResponse(response, err, utils.TestEntity,
+					"Runtime Config", "Read")
 			}
-			return utils.ErrorFromHTTPResponse(response, err, utils.TestEntity,
-				"Runtime Config", "Read")
-		}
-		if value == testValue {
-			return fmt.Errorf(
-				"runtime config key %q in scope %q still has test value %q after destroy",
-				key, scope, value)
-		}
-		return nil
+			if value == testValue {
+				return fmt.Errorf(
+					"runtime config key %q in scope %q still has test value %q after destroy",
+					key, scope, value)
+			}
+			return nil
+		})
 	}
 }

--- a/templates/guides/managing-private-yba-over-ssh-tunnel.md
+++ b/templates/guides/managing-private-yba-over-ssh-tunnel.md
@@ -1,0 +1,206 @@
+---
+subcategory: ""
+page_title: "Managing a private YBA over an SSH tunnel"
+description: |-
+  Using the Terraform provider against a YugabyteDB Anywhere host with no reachable API endpoint, via a local port-forward
+---
+
+# Managing a private YBA over an SSH tunnel
+
+Many YugabyteDB Anywhere (YBA) installations run inside a private VPC or a
+locked-down network where the API port is not reachable from the machine
+that runs Terraform. The provider itself only needs an HTTPS (or HTTP)
+endpoint it can connect to - it has no notion of SSH or tunnels. If you can
+SSH to the YBA VM, an SSH local port-forward is all it takes: the forward
+opens a listener on the Terraform runner, and the provider talks to that
+listener as if it were YBA.
+
+The tunnel is entirely out-of-band. You start it yourself, outside of
+Terraform, before running `terraform plan` / `apply` / `destroy`, and keep it
+open for the duration of the run. The provider configuration has no
+tunnel-specific fields - it just points `host` at the local address the
+tunnel is listening on.
+
+Two machines are involved throughout this page:
+
+- **Terraform runner** - the machine that executes `terraform` (your
+  workstation or a CI runner). The tunnel command runs *here*, and the
+  forwarded ports open *here*.
+- **YBA VM** - the private host running (or about to run) YBA. It is the
+  SSH destination; nothing on it needs to change.
+
+## How the YBA API becomes reachable
+
+The examples on this page forward two ports:
+
+| Listens on (Terraform runner) | Forwards to (YBA VM) | Used by |
+| --- | --- | --- |
+| `127.0.0.1:9443` | `443` - the YBA API | The provider (`host`) |
+| `127.0.0.1:2222` | `22` - the VM's `sshd` | `yba_installer` only |
+
+While the tunnel is up, the YBA API - normally `https://<yba-vm>:443` inside
+the private network - is reachable from the Terraform runner as
+`https://127.0.0.1:9443`. The second forward is only needed if you use
+`yba_installer` to install or manage YBA on the node over SSH; skip it when
+managing an already-installed YBA.
+
+The local ports `9443` and `2222` are arbitrary conventions used throughout
+this page - any free local ports work.
+
+## Start the tunnel
+
+On the **Terraform runner**, run:
+
+```sh
+ssh -N -L 9443:localhost:443 -L 2222:localhost:22 user@yba-vm
+```
+
+Breaking that down:
+
+| Part | Side | Meaning |
+| --- | --- | --- |
+| `user@yba-vm` | YBA VM | The SSH login on the YBA VM. |
+| `-L 9443:localhost:443` | both | Listen on port `9443` on the Terraform runner; forward connections to port `443` on the YBA VM. |
+| `-L 2222:localhost:22` | both | Listen on port `2222` on the Terraform runner; forward to the YBA VM's own `sshd` on `22`. Only needed for `yba_installer`. |
+| `-N` | - | Do not run a remote command - tunnel only. |
+
+In each `-L local:host:port` forward, the *first* port is opened on the
+Terraform runner, and `host:port` is resolved *from the YBA VM's
+perspective* - `localhost:443` means port 443 on the YBA VM itself, not on
+your machine.
+
+Verify the API is reachable before running Terraform:
+
+```sh
+curl -k https://127.0.0.1:9443
+```
+
+Keep the `ssh` process running for as long as you need Terraform to talk to
+YBA - closing the tunnel mid-`apply` fails the in-flight API calls the same
+way any other network interruption would.
+
+~> **Note:** If the Terraform runner cannot SSH to the YBA VM directly, hop
+through a reachable host with `-J user@jump-host`, or SSH to that host and
+replace `localhost` in the forwards with the YBA VM's private address as
+seen from there. The command still runs on the Terraform runner, and the
+provider configuration below is unchanged. The same applies to cloud-native
+port-forwarding tools (`gcloud compute ssh -- -L ...`, AWS SSM port
+forwarding, `az network bastion tunnel`): anything that produces a local
+TCP listener on the Terraform runner works identically.
+
+## Point the provider at the tunnel
+
+The provider's `host` argument takes an IP address or domain name with port,
+no scheme:
+
+```terraform
+provider "yba" {
+  host      = "127.0.0.1:9443"
+  api_token = var.yba_api_token
+}
+```
+
+Since the tunnel's listener is on the Terraform runner, `host` is always
+`127.0.0.1` (or `localhost`) plus the local port you chose - `9443` in these
+examples - regardless of where the YBA VM actually lives.
+
+## TLS behavior over the tunnel
+
+~> **Note:** The provider does not validate the YBA server's TLS
+certificate (neither the chain nor the hostname) under any circumstances,
+tunneled or not. A connection to `127.0.0.1:9443` therefore succeeds even though the
+certificate YBA presents was issued for a different hostname; there is
+nothing to enable or work around for the tunnel scenario specifically.
+Practically, this means the SSH tunnel itself is what authenticates and
+encrypts the hop to the VM - treat the tunnel, not the HTTPS layer on top of
+it, as the real security boundary.
+
+## Installing YBA through the same tunnel
+
+`yba_installer` drives the install over SSH, so point its SSH fields at the
+forwarded `sshd` port on the Terraform runner instead of the VM's real
+address:
+
+```terraform
+resource "yba_installer" "install" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "127.0.0.1"
+  ssh_port    = 2222
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key = var.ssh_private_key
+  yba_version     = "<yba-version-with-build-number>"
+}
+```
+
+`ssh_port` is optional and defaults to `22`; set it only when, as here,
+`sshd` is reachable through a forwarded port rather than directly on `22`.
+
+~> **Note:** `yba_installer` downloads the YBA install bundle *on the node
+itself* - the install commands run over the SSH session and include a
+`curl -O` against `downloads.yugabyte.com` (or `releases.yugabyte.com` for
+pre-release/CI builds), not against your workstation. The tunnel only needs
+to carry the SSH session; the YBA VM needs its own outbound network path to
+`downloads.yugabyte.com` / `releases.yugabyte.com` to complete the install.
+
+## Complete example
+
+Putting it together: start the tunnel on the Terraform runner, then apply a
+configuration that installs YBA over the forwarded `sshd`, creates the
+initial customer through an unauthenticated provider, and is ready for
+further resources through an authenticated one.
+
+```sh
+ssh -N -L 9443:localhost:443 -L 2222:localhost:22 user@yba-vm
+```
+
+```terraform
+terraform {
+  required_providers {
+    yba = {
+      source  = "yugabyte/yba"
+      version = "~> 1.0"
+    }
+  }
+}
+
+provider "yba" {
+  alias = "unauthenticated"
+  host  = "127.0.0.1:9443"
+}
+
+resource "yba_installer" "install" {
+  provider    = yba.unauthenticated
+  ssh_host_ip = "127.0.0.1"
+  ssh_port    = 2222
+  ssh_user    = "<ssh-user>"
+
+  ssh_private_key = var.ssh_private_key
+  yba_version     = "<yba-version-with-build-number>"
+}
+
+variable "customer_password" {
+  type      = string
+  sensitive = true
+}
+
+resource "yba_customer_resource" "customer" {
+  provider   = yba.unauthenticated
+  depends_on = [yba_installer.install]
+  code       = "admin"
+  email      = "<email>"
+  name       = "<customer-name>"
+  password   = var.customer_password
+}
+
+provider "yba" {
+  host      = "127.0.0.1:9443"
+  api_token = yba_customer_resource.customer.api_token
+}
+```
+
+Once the customer resource is created, switch subsequent resources
+(providers, universes, storage configs, and so on) to the authenticated
+`yba` provider, same as any other YBA installation. See
+[Running Terraform on existing YugabyteDB Anywhere installations](running-terraform-on-existing-yba-installations)
+for that hand-off in more detail.


### PR DESCRIPTION
### Description
Adds field for SSH port to yba installer resource. This will allow installation of YBA on a remote machine that is only accessible through local port forwarding. 

### Testing
Unit tests for port handling
In conjunction with other PRs for final acceptance test removing public internet from acceptance 
