### PR TITLE
Multiplexing SSH tunnel over single port forward

### DIFF
--- a/acctest/README.md
+++ b/acctest/README.md
@@ -31,7 +31,11 @@ tunnel, which authenticates callers with IAM before any packet reaches the VM.
 The env's YBA endpoints are therefore `127.0.0.1:9443`, and `make acctest`
 opens the tunnel itself (`acctest/with-yba-tunnel.sh`, the same path CI and
 the fixture targets use) as the fixture service account — no personal IAP
-grant or extra terminal needed. To browse the UI, hold a tunnel open with:
+grant or extra terminal needed. Test runs carry the API leg as one
+multiplexed SSH connection over the relay (the fixture SSH key rides in the
+env), so the suite's per-process connection churn never hits the relay's
+per-connection handshake, which flakes under burst. To browse the UI, hold a
+tunnel open with:
 
 ```bash
 acctest/with-yba-tunnel.sh sleep 86400   # then open https://127.0.0.1:9443
@@ -57,10 +61,15 @@ interactive), so run it yourself.
 - **Auth error** (`could not find default credentials`, `Reauthentication
   failed`, `no usable gcloud login`, `403`): re-run `make -C acctest auth` —
   it detects expired sessions, not just missing ones.
-- **`IAP tunnel ... did not become ready`** (or `connection refused` to
+- **`tunnel ... did not become ready`** (or `connection refused` to
   `127.0.0.1:9443`): check `gcloud` is installed and the env is fresh — the
   tunnel authenticates as the fixture SA from `TF_VAR_GCP_CREDENTIALS`, so a
   rotated key means a stale env (see below).
+- **`connection reset by peer` or tests hanging mid-suite**: the env predates
+  `YBA_SSH_PRIVATE_KEY_B64`, so the tunnel silently fell back to per-connection
+  IAP forwards, which flake under test churn. Regenerate the env (below); in
+  CI, refresh the `ACCTEST_ENV` secret with `make -C acctest
+  push-github-secrets`.
 - **Every test is SKIPPED**: the env was not loaded. Run `make -C acctest env`,
   confirm `acctest/env` exists, then `make acctest`.
 - **Env looks stale** (after re-applying a fixture, or rotated keys): delete it

--- a/acctest/gcp/out-vars.tf
+++ b/acctest/gcp/out-vars.tf
@@ -15,6 +15,14 @@
 # Both are the tunnel-local endpoint (local.yba_api_host): the standing YBA has
 # no direct ingress. Every consumer tunnels via acctest/with-yba-tunnel.sh —
 # `make acctest` (CI and local) and the apply-gcp/destroy-gcp fixture targets.
+#
+# YBA_SSH_USER/YBA_SSH_PRIVATE_KEY_B64 let with-yba-tunnel.sh carry the API leg
+# as one multiplexed SSH connection instead of per-connection IAP forwards,
+# which flake under test-suite connection churn (see that script). The key is
+# the fixture keypair the installer already uses (tls_private_key.yba); it
+# lives in the remote state either way — this line only transports it to CI
+# through the ACCTEST_ENV secret, next to the SA key and API token it already
+# holds. Base64 keeps the env one line per key.
 
 locals {
   test_env = <<-EOT
@@ -30,6 +38,8 @@ locals {
     TF_VAR_GCP_YBA_API_KEY='${yba_customer_resource.customer.api_token}'
     YBA_HOST='${local.yba_api_host}'
     YBA_API_KEY='${yba_customer_resource.customer.api_token}'
+    YBA_SSH_USER='yugabyte'
+    YBA_SSH_PRIVATE_KEY_B64='${base64encode(tls_private_key.yba.private_key_openssh)}'
   EOT
 }
 
@@ -37,7 +47,7 @@ locals {
 output "test_env" {
   description = "Acceptance-test env (TF_VAR_GCP_*, YBA endpoint) as KEY='value' lines."
   value       = local.test_env
-  sensitive   = true # contains GCP_CREDENTIALS and YBA API tokens
+  sensitive   = true # contains GCP_CREDENTIALS, YBA API tokens, and the YBA VM SSH key
 }
 
 output "yba_url" {

--- a/acctest/with-yba-tunnel.sh
+++ b/acctest/with-yba-tunnel.sh
@@ -2,8 +2,8 @@
 # Copyright 2026 YugabyteDB, Inc.
 # SPDX-License-Identifier: MPL-2.0
 #
-# with-yba-tunnel.sh [-s] <command...> — run <command> with an IAP tunnel to
-# the standing YBA up (127.0.0.1:9443 -> VM:443; the VM accepts no direct
+# with-yba-tunnel.sh [-s] <command...> — run <command> with a tunnel to the
+# standing YBA up (127.0.0.1:9443 -> VM:443; the VM accepts no direct
 # ingress). The single owner of the tunnel constants and logic:
 #
 #   - `make acctest` / `make acctest-long` (CI and local, identically): opens
@@ -15,6 +15,19 @@
 #     the API leg — but bounded, warning and proceeding on timeout: on a
 #     first-ever apply nothing can answer until terraform has created the VM
 #     and installed YBA, and that flow only reaches the API after the install.
+#
+# The API leg has two shapes. With the fixture SSH key in the env
+# (YBA_SSH_PRIVATE_KEY_B64, set for test runs), it is an `ssh -L` forward
+# carried over ONE IAP WebSocket (start-iap-tunnel --listen-on-stdin). The
+# test suite spawns a fresh provider process per terraform command, each
+# dialing new TCP connections; a per-connection IAP forward does a full relay
+# handshake for every one, and under the burst when test packages rotate some
+# handshakes fail — the client sees resets or, worse, black holes that eat
+# the whole 20m go-test timeout. SSH multiplexes each connection as a channel
+# on the established transport, so new connections never touch the relay.
+# Without the key (fixture ops — on a first apply the keypair does not exist
+# yet), the leg falls back to the per-connection forward, which the one-shot
+# fixture flows never stress.
 #
 # Auth: the fixture service account when TF_VAR_GCP_CREDENTIALS is set (test
 # runs source acctest/env), inside an isolated CLOUDSDK_CONFIG so the caller's
@@ -50,7 +63,8 @@ umask 077
 tmp=$(mktemp -d)
 loop_pids=
 cleanup() {
-  # Kill each retry loop first (stops respawning), then the gcloud it recorded.
+  # Kill each retry loop first (stops respawning), then the tunnel process it
+  # recorded (ssh takes its ProxyCommand gcloud down with it).
   for p in $loop_pids; do kill "$p" 2>/dev/null || true; done
   for f in "$tmp"/leg-*.pid; do
     [ -f "$f" ] && kill "$(cat "$f")" 2>/dev/null || true
@@ -83,7 +97,36 @@ leg() { # leg <vm-port> <local-port>
   loop_pids="$loop_pids $!"
 }
 
-leg 443 9443
+# The multiplexed API leg (see header). Host-key checking is off: the key file
+# is written fresh each run, IAP already authenticates the endpoint by IAM,
+# and the API traffic inside is TLS anyway. ServerAlive* makes ssh exit when
+# the relay goes quiet, so the retry loop replaces it within seconds;
+# ExitOnForwardFailure covers the duplicate-listener case the same way a
+# failed gcloud bind does.
+ssh_mux_leg() {
+  printf '%s' "$YBA_SSH_PRIVATE_KEY_B64" | base64 -d >"$tmp/ssh-key"
+  ( while :; do
+      ssh -N \
+        -i "$tmp/ssh-key" \
+        -o ProxyCommand="gcloud compute start-iap-tunnel $VM 22 --listen-on-stdin --project=$PROJECT --zone=$ZONE" \
+        -o BatchMode=yes -o IdentitiesOnly=yes -o ConnectTimeout=30 \
+        -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
+        -o ExitOnForwardFailure=yes \
+        -o ServerAliveInterval=15 -o ServerAliveCountMax=3 \
+        -L 127.0.0.1:9443:127.0.0.1:443 \
+        "${YBA_SSH_USER:-yugabyte}@$VM" >>"$tmp/leg-443.log" 2>&1 &
+      echo $! >"$tmp/leg-443.pid"
+      wait $! || true
+      sleep 5
+    done ) &
+  loop_pids="$loop_pids $!"
+}
+
+if [ -n "${YBA_SSH_PRIVATE_KEY_B64:-}" ]; then
+  ssh_mux_leg
+else
+  leg 443 9443
+fi
 if [ -n "$ssh_leg" ]; then
   leg 22 2222
   for _ in $(seq 1 12); do
@@ -104,12 +147,17 @@ fi
 
 for _ in $(seq 1 30); do
   if ready; then
-    "$@"
-    exit $?
+    rc=0
+    "$@" || rc=$?
+    if [ "$rc" -ne 0 ]; then
+      echo "with-yba-tunnel: command failed (rc=$rc); tunnel logs:" >&2
+      cat "$tmp"/leg-*.log >&2 || true
+    fi
+    exit "$rc"
   fi
   sleep 2
 done
 
-echo "IAP tunnel to the standing YBA did not become ready:" >&2
+echo "tunnel to the standing YBA did not become ready:" >&2
 cat "$tmp"/leg-*.log >&2
 exit 1

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -57,7 +58,17 @@ func NewAPIClient(enableHTTPS bool, host, apiKey string) (*APIClient, error) {
 	cfgV2 := clientv2.NewConfiguration()
 	cfgV2.Host = host
 	if enableHTTPS {
-		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
+		// Bound connection setup and time-to-first-byte. Without these, a
+		// connection that dies without an RST (a black-holed load balancer or
+		// tunnel) hangs its request forever — GetSessionInfo below runs on
+		// context.Background(), so provider configure would never return. No
+		// overall client Timeout: response bodies of any size stay unbounded.
+		tr := &http.Transport{
+			TLSClientConfig:       &tls.Config{InsecureSkipVerify: true},
+			DialContext:           (&net.Dialer{Timeout: 30 * time.Second}).DialContext,
+			TLSHandshakeTimeout:   30 * time.Second,
+			ResponseHeaderTimeout: 2 * time.Minute,
+		}
 		cfg.Scheme = "https"
 		cfg.HTTPClient = &http.Client{Transport: tr}
 		cfgV2.Scheme = "https"

--- a/internal/api/api_test.go
+++ b/internal/api/api_test.go
@@ -1,0 +1,52 @@
+// Licensed to YugabyteDB, Inc. under one or more contributor license
+// agreements. See the NOTICE file distributed with this work for
+// additional information regarding copyright ownership. Yugabyte
+// licenses this file to you under the Mozilla License, Version 2.0
+// (the "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+// http://mozilla.org/MPL/2.0/.
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package api
+
+import (
+	"net/http"
+	"testing"
+)
+
+// TestNewAPIClientTransportTimeouts: the generated clients' transport must
+// bound dial, TLS handshake, and time-to-first-byte. GetSessionInfo runs on
+// context.Background() during provider configure, so a connection that dies
+// without an RST (black-holed load balancer or tunnel) would otherwise hang
+// every terraform command forever.
+func TestNewAPIClientTransportTimeouts(t *testing.T) {
+	// Empty API key skips the GetSessionInfo call, so no server is needed.
+	c, err := NewAPIClient(true, "127.0.0.1:1", "")
+	if err != nil {
+		t.Fatalf("NewAPIClient: %v", err)
+	}
+	for name, hc := range map[string]*http.Client{
+		"v1": c.YugawareClient.GetConfig().HTTPClient,
+		"v2": c.YugawareClientV2.GetConfig().HTTPClient,
+	} {
+		tr, ok := hc.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("%s client: transport is %T, want *http.Transport", name, hc.Transport)
+		}
+		if tr.DialContext == nil {
+			t.Errorf("%s client: no dial timeout (DialContext is nil)", name)
+		}
+		if tr.TLSHandshakeTimeout <= 0 {
+			t.Errorf("%s client: TLSHandshakeTimeout not set", name)
+		}
+		if tr.ResponseHeaderTimeout <= 0 {
+			t.Errorf("%s client: ResponseHeaderTimeout not set", name)
+		}
+	}
+}


### PR DESCRIPTION
### Description
Each acceptance test spawning a new gcloud iap tunnel would cause flakiness, so this test instead only starts one tunnel and allows all the tests to use it at local:9443. Because of this now need SSH key to do the local forwarding (which we get from deploying the YBA VM). Also adds timeouts to API so we don't hang when the connection isn't there. 
